### PR TITLE
Fix dependency between tests that caused some to pass when they should have failed

### DIFF
--- a/entropylab/results_backend/sqlalchemy/db.py
+++ b/entropylab/results_backend/sqlalchemy/db.py
@@ -62,7 +62,7 @@ class SqlAlchemyDB(DataWriter, DataReader, PersistentLabDB):
      and DataReader) and lab resources (PersistentLabDB)
     """
 
-    def __init__(self, path=None, echo=False):
+    def __init__(self, path=None, echo=False, **kwargs):
         """
             Database implementation using SqlAlchemy package for results (DataWriter
             and DataReader) and lab resources (PersistentLabDB)
@@ -70,6 +70,7 @@ class SqlAlchemyDB(DataWriter, DataReader, PersistentLabDB):
         :param echo: if True, the database engine will log all statements
         """
         super(SqlAlchemyDB, self).__init__()
+        self._enable_hdf5_storage = kwargs.get("enable_hdf5_storage")
         self._engine, self._storage = _DbInitializer(path, echo=echo).init_db()
         self._Session = sessionmaker(bind=self._engine)
 
@@ -458,7 +459,12 @@ class SqlAlchemyDB(DataWriter, DataReader, PersistentLabDB):
             else:
                 return set()
 
-    @staticmethod
-    def __hdf5_storage_enabled() -> bool:
-        """ Feature toggle for 'hdf5 storage' feature """
-        return settings.get("toggles.hdf5_storage", True)
+    def __hdf5_storage_enabled(self) -> bool:
+        """Feature toggle for 'hdf5 storage' feature
+
+        Class member set in __init__() overrides config setting"""
+        if self._enable_hdf5_storage is None:
+            enabled = settings.get("toggles.hdf5_storage", True)
+        else:
+            enabled = self._enable_hdf5_storage
+        return enabled

--- a/entropylab/results_backend/sqlalchemy/tests/test_db.py
+++ b/entropylab/results_backend/sqlalchemy/tests/test_db.py
@@ -3,17 +3,15 @@ from pathlib import Path
 
 import pytest
 
-from config import settings
 from entropylab import SqlAlchemyDB, RawResultData
 
 
 def test_save_result_raises_when_same_result_saved_twice(request):
     # arrange
-    settings.toggles = {"hdf5_storage": True}  # this feature is new in HDF5Storage
     path = f"./tests_cache/{request.node.name}.db"
-    hdf5_path = Path(path).with_suffix(".hdf5")
+    hdf5_path = str(Path(path).with_suffix(".hdf5"))
     try:
-        db = SqlAlchemyDB(path, echo=True)
+        db = SqlAlchemyDB(path, echo=True, enable_hdf5_storage=True)
         raw_result = RawResultData(stage=1, label="foo", data=42)
         db.save_result(0, raw_result)
         with pytest.raises(ValueError):

--- a/entropylab/results_backend/sqlalchemy/tests/test_db_initializer.py
+++ b/entropylab/results_backend/sqlalchemy/tests/test_db_initializer.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from pathlib import Path
 from shutil import copyfile
 
-from config import settings
 from entropylab import SqlAlchemyDB, RawResultData
 from entropylab.api.data_writer import Metadata
 from entropylab.results_backend.sqlalchemy.storage import HDF5Storage
@@ -14,7 +13,7 @@ def test_upgrade_db_when_initial_db_is_empty(request):
     # arrange
     db_template = f"./db_templates/initial.db"
     db_under_test = _get_test_file_name(db_template)
-    hdf5_under_test = Path(db_under_test).with_suffix(".hdf5")
+    hdf5_under_test = str(Path(db_under_test).with_suffix(".hdf5"))
     try:
         _copy_db(db_template, db_under_test, request)
 
@@ -54,11 +53,11 @@ def test_upgrade_db_when_db_is_in_memory():
 
 def test__migrate_results_to_hdf5(request):
     # arrange
-    settings.toggles = {"hdf5_storage": False}
     path = f"./tests_cache/{request.node.name}.db"
-    hdf5_path = Path(path).with_suffix(".hdf5")
+    hdf5_path = str(Path(path).with_suffix(".hdf5"))
     try:
-        db = SqlAlchemyDB(path, echo=True)
+        # save to DB but not to storage:
+        db = SqlAlchemyDB(path, echo=True, enable_hdf5_storage=False)
         db.save_result(1, RawResultData(stage=1, label="foo", data="bar"))
         db.save_result(1, RawResultData(stage=1, label="baz", data="buz"))
         db.save_result(1, RawResultData(stage=2, label="biz", data="bez"))
@@ -82,11 +81,11 @@ def test__migrate_results_to_hdf5(request):
 
 def test__migrate_metadata_to_hdf5(request):
     # arrange
-    settings.toggles = {"hdf5_storage": False}
     path = f"./tests_cache/{request.node.name}.db"
-    hdf5_path = Path(path).with_suffix(".hdf5")
+    hdf5_path = str(Path(path).with_suffix(".hdf5"))
     try:
-        db = SqlAlchemyDB(path, echo=True)
+        # save to DB but not to storage:
+        db = SqlAlchemyDB(path, echo=True, enable_hdf5_storage=False)
         db.save_metadata(1, Metadata(stage=1, label="foo", data="bar"))
         db.save_metadata(1, Metadata(stage=1, label="baz", data="buz"))
         db.save_metadata(1, Metadata(stage=2, label="biz", data="bez"))

--- a/entropylab/tests/test_executor.py
+++ b/entropylab/tests/test_executor.py
@@ -30,10 +30,10 @@ def an_experiment(context: EntropyContext):
     a1 = do_something()
     scope.get_trig()
     for i in range(30):
-        context.add_result("a_result", a1 + i + datetime.now().microsecond)
+        context.add_result("a_result" + str(i), a1 + i + datetime.now().microsecond)
 
         b1 = do_something2()
-        context.add_result("b_result", b1 + i + datetime.now().microsecond)
+        context.add_result("b_result" + str(i), b1 + i + datetime.now().microsecond)
 
     micro = datetime.now().microsecond
     context.add_result(
@@ -59,10 +59,10 @@ def an_experiment_with_plot(experiment: EntropyContext):
     a1 = do_something()
     scope.get_trig()
     for i in range(30):
-        experiment.add_result("a_result", a1 + i + datetime.now().microsecond)
+        experiment.add_result("a_result" + str(i), a1 + i + datetime.now().microsecond)
 
         b1 = do_something2()
-        experiment.add_result("b_result", b1 + i + datetime.now().microsecond)
+        experiment.add_result("b_result" + str(i), b1 + i + datetime.now().microsecond)
 
     micro = datetime.now().microsecond
     experiment.add_plot(
@@ -116,10 +116,11 @@ def test_running_no_db():
 
 @pytest.mark.repeat(3)
 def test_running_db():
+    db_name = f"tests_cache/test_running_db_{datetime.now():%Y-%m-%d-%H-%M-%S}.db"
     try:
         resources = ExperimentResources()
         resources.add_temp_resource("scope_1", MockScope("1.1.1.1", ""))
-        db = SqlAlchemyDB("my_db.db")
+        db = SqlAlchemyDB(db_name)
 
         definition = Script(resources, an_experiment, "with_db")
 
@@ -128,17 +129,22 @@ def test_running_db():
         print(reader.get_experiment_info())
         print(reader.get_experiment_info().script.print_all())
 
-        db = SqlAlchemyDB("my_db.db")
+        db = SqlAlchemyDB(db_name)
         definition = Script(resources, an_experiment_with_plot, "with_db")
         definition.run(db)
     finally:
-        os.remove("my_db.db")
+        os.remove(db_name)
+        os.remove(db_name.replace(".db", ".hdf5"))
 
 
 def test_running_db_and_topology():
+    db_name = (
+        f"tests_cache/test_running_db_and_topology_"
+        f"{datetime.now():%Y-%m-%d-%H-%M-%S}.db"
+    )
     try:
         # setup lab environment one time
-        db = SqlAlchemyDB("db_and_topo.db")
+        db = SqlAlchemyDB(db_name)
         lab = LabResources(db)
         lab.register_resource(
             "scope_1",
@@ -202,14 +208,18 @@ def test_running_db_and_topology():
         print(reader.get_experiment_info().script.print_all())
 
     finally:
-        os.remove("db_and_topo.db")
-        pass
+        os.remove(db_name)
+        os.remove(db_name.replace(".db", ".hdf5"))
 
 
 def test_running_db_and_topology_with_kwargs():
+    db_name = (
+        f"tests_cache/test_running_db_and_topology_with_kwargs_"
+        f"{datetime.now():%Y-%m-%d-%H-%M-%S}.db"
+    )
     try:
         # setup lab environment one time
-        db = SqlAlchemyDB("db_and_topo.db")
+        db = SqlAlchemyDB(db_name)
         lab = LabResources(db)
         lab.register_resource(
             "scope_1",
@@ -244,8 +254,8 @@ def test_running_db_and_topology_with_kwargs():
         print(reader.get_experiment_info())
         print(reader.get_experiment_info().script.print_all())
     finally:
-        os.remove("db_and_topo.db")
-        pass
+        os.remove(db_name)
+        os.remove(db_name.replace(".db", ".hdf5"))
 
 
 def test_executor_decorator():

--- a/entropylab/tests/test_graph_read_results.py
+++ b/entropylab/tests/test_graph_read_results.py
@@ -62,6 +62,7 @@ def test_async_graph_single_data_reader():
     finally:
         print("deleting db")
         os.remove("test_running_db_graph.db")
+        os.remove("test_running_db_graph.hdf5")
         pass
 
 
@@ -90,4 +91,5 @@ def test_async_graph_multi_data_reader():
     finally:
         print("deleting db")
         os.remove("test_running_db_graph1.db")
+        os.remove("test_running_db_graph1.hdf5")
         pass


### PR DESCRIPTION
We had a few tests disabling the use of the new "hdf5 storage" feature by setting a value in the global `settings` from `config.py`. As this setting is static it affected other tests where the feature should have been enabled. As a result some of the "other" tests that were broken were passing green when they should have been failing red.

This PR circumvents the global dependency in tests by allowing the feature to be disabled through the `SqlAlchemy()` constructor. Additionally the failing tests were fixed to pass.
