### PR TITLE
alembic.ini - Set console handler log level to WARN

### DIFF
--- a/entropylab/results_backend/sqlalchemy/alembic.ini
+++ b/entropylab/results_backend/sqlalchemy/alembic.ini
@@ -87,7 +87,7 @@ qualname = alembic
 [handler_console]
 class = StreamHandler
 args = (sys.stderr,)
-level = NOTSET
+level = WARN
 formatter = generic
 
 [formatter_generic]


### PR DESCRIPTION
On `main`, when `SqlAlchemyDB()` is invoked it internally runs alembic migrations and outputs `INFO` log messages to `stderr` similar to this:

> INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running stamp_revision  -> 04ae19b32c08

This is TMI for Entropy users so this patch PR changes alembic's minimal log level for output to `stderr` to `WARN` to not have these messages shown.