### PR TITLE
Dashboard: Persisting user selection across page reload

### DIFF
--- a/entropylab/results/dashboard/dashboard.py
+++ b/entropylab/results/dashboard/dashboard.py
@@ -50,15 +50,18 @@ def build_dashboard_app(path):
 
     @_app.callback(
         Output("plot-tabs", "children"),
-        Input("experiments-table", "selected_row_ids"),
+        State("experiments-table", "data"),
+        Input("experiments-table", "selected_rows"),
     )
     def render_plot_tabs_from_selected_experiments_table_rows(
-        selected_row_ids,
+        data,
+        selected_rows,
     ):
         result = []
         failed_exp_ids = []
-        if selected_row_ids:
-            for exp_id in selected_row_ids:
+        if selected_rows:
+            for row_num in selected_rows:
+                exp_id = data[row_num]["id"]
                 plots = _dashboard_data_reader.get_plot_data(exp_id)
                 if plots:
                     for plot in plots:

--- a/entropylab/results/dashboard/dashboard.py
+++ b/entropylab/results/dashboard/dashboard.py
@@ -125,68 +125,51 @@ def build_dashboard_app(path):
         )
 
     @_app.callback(
-        Output("aggregate-tab", "children"),
-        Output("remove-buttons", "children"),
         Output("plot-keys-to-combine", "data"),
-        Input({"type": "remove-button", "index": ALL}, "n_clicks"),
         Input("add-button", "n_clicks"),
+        Input({"type": "remove-button", "index": ALL}, "n_clicks"),
         State("plot-tabs", "active_tab"),
-        State("plot-figures", "data"),
         State("plot-keys-to-combine", "data"),
     )
-    def add_or_remove_plot_in_combined_plot(
-        n_clicks1, n_clicks2, active_tab, plot_figures, plot_keys_to_combine
+    def add_or_remove_plot_keys_based_on_click_events(
+        n_clicks1, n_clicks2, active_tab, plot_keys_to_combine
     ):
         plot_keys_to_combine = plot_keys_to_combine or []
         prop_id = dash.callback_context.triggered[0]["prop_id"]
-        # trigger was a click on the "Add >>" button
         if prop_id == "add-button.n_clicks" and active_tab:
             active_plot_key = active_tab.replace("plot-tab-", "")
             if active_plot_key not in plot_keys_to_combine:
                 plot_keys_to_combine.append(active_plot_key)
-            tabs, remove_buttons = build_aggregate_graph_and_remove_buttons(
-                plot_figures, plot_keys_to_combine
-            )
-            return (
-                tabs,
-                remove_buttons,
-                plot_keys_to_combine,
-            )
-        # trigger was a click on one of the remove buttons
         elif "remove-button" in prop_id:
             id_dict = json.loads(prop_id.replace(".n_clicks", ""))
             remove_plot_key = id_dict["index"]
             if remove_plot_key in plot_keys_to_combine:
                 plot_keys_to_combine.remove(remove_plot_key)
+        return plot_keys_to_combine
 
-                tabs, remove_buttons = build_aggregate_graph_and_remove_buttons(
-                    plot_figures, plot_keys_to_combine
-                )
-                return (
-                    tabs,
-                    remove_buttons,
-                    plot_keys_to_combine,
-                )
-
-        # default case
+    @_app.callback(
+        Output("aggregate-tab", "children"),
+        Output("remove-buttons", "children"),
+        Input("plot-keys-to-combine", "data"),
+        State("plot-figures", "data"),
+    )
+    def build_combined_plot_from_plot_keys(plot_keys_to_combine, plot_figures):
+        if plot_keys_to_combine and len(plot_keys_to_combine) > 0:
+            combined_figure = make_subplots(specs=[[{"secondary_y": True}]])
+            remove_buttons = []
+            for plot_id in plot_keys_to_combine:
+                figure = plot_figures[plot_id]["figure"]
+                color = plot_figures[plot_id]["color"]
+                combined_figure.add_trace(figure["data"][0])
+                button = build_remove_button(plot_id, color)
+                remove_buttons.append(button)
+            combined_figure.update_layout(dark_plot_layout)
+            return dcc.Graph(figure=combined_figure, responsive=True), remove_buttons
         else:
             return (
                 [build_aggregate_tab_placeholder()],
                 [html.Div()],
-                plot_keys_to_combine,
             )
-
-    def build_aggregate_graph_and_remove_buttons(plot_figures, plot_keys_to_combine):
-        combined_figure = make_subplots(specs=[[{"secondary_y": True}]])
-        remove_buttons = []
-        for plot_id in plot_keys_to_combine:
-            figure = plot_figures[plot_id]["figure"]
-            color = plot_figures[plot_id]["color"]
-            combined_figure.add_trace(figure["data"][0])
-            button = build_remove_button(plot_id, color)
-            remove_buttons.append(button)
-        combined_figure.update_layout(dark_plot_layout)
-        return dcc.Graph(figure=combined_figure, responsive=True), remove_buttons
 
     def build_remove_button(plot_id, color):
         return dbc.Button(

--- a/entropylab/results/dashboard/layout.py
+++ b/entropylab/results/dashboard/layout.py
@@ -1,13 +1,16 @@
-from dash import html
 import dash_bootstrap_components as dbc
-from entropylab.results_backend.sqlalchemy.project import project_name, project_path
+from dash import html, dcc
+
 from entropylab.results.dashboard.table import table
+from entropylab.results_backend.sqlalchemy.project import project_name, project_path
 
 
 def layout(path: str, records: dict):
     return dbc.Container(
         className="main",
         children=[
+            dcc.Store(id="plot-figures", storage_type="session"),
+            dcc.Store(id="plot-keys-to-combine", storage_type="session"),
             dbc.Row(
                 dbc.Navbar(
                     dbc.Container(
@@ -76,6 +79,7 @@ def layout(path: str, records: dict):
                                     id="aggregate-tab",
                                 )
                             ],
+                            persistence=True,
                         ),
                         width="5",
                     ),

--- a/entropylab/results/dashboard/table.py
+++ b/entropylab/results/dashboard/table.py
@@ -15,6 +15,7 @@ def table(records):
             dict(name="success", id="success"),
         ],
         data=records,
+        persistence=True,
         row_selectable="multi",
         cell_selectable=False,
         sort_action="native",


### PR DESCRIPTION
This PR resolves https://github.com/entropy-lab/entropy/issues/106 . The state of the user's selection of experiments to plot and of plots to combine in the aggregate plot is persisted even when the browser page is reloaded.