### PR TITLE
Dashboard: Use production WSGI server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * New results dashboard web application
 * Dashboard: Auto plot last result
+* Dashboard: Serve using production-grade WSGI server (waitress 2.0.0)
 
 ## [0.3.0] - 2021-10-11
 ### Added

--- a/entropylab/cli/main.py
+++ b/entropylab/cli/main.py
@@ -7,7 +7,7 @@ from entropylab.results.dashboard import serve_dashboard
 from entropylab.results_backend.sqlalchemy import init_db, upgrade_db
 
 
-# decorator
+# Decorator for friendly error messages
 
 
 def command(func: callable) -> callable:
@@ -43,7 +43,10 @@ def update(args: argparse.Namespace):
 
 @command
 def serve(args: argparse.Namespace):
-    serve_dashboard(args.directory, args.debug)
+    serve_dashboard(args.directory, args.host, args.port, args.debug)
+
+
+# The parser
 
 
 def _build_parser():
@@ -75,6 +78,18 @@ def _build_parser():
         "serve", help="serve & launch the results dashboard app in a browser"
     )
     serve_parser.add_argument("directory", **directory_arg)
+    serve_parser.add_argument(
+        "host",
+        help="host name from which to serve the dashboard app",
+        nargs="?",
+        default=None,
+    )
+    serve_parser.add_argument(
+        "port",
+        help="port number from which to serve the dashboard app",
+        nargs="?",
+        default=None,
+    )
     serve_parser.add_argument("--debug", dest="debug", action="store_true")
     serve_parser.set_defaults(func=serve, debug=False)
 

--- a/entropylab/cli/tests/test_main.py
+++ b/entropylab/cli/tests/test_main.py
@@ -9,7 +9,7 @@ from entropylab.cli.main import init, command
 
 def test_init_with_no_args():
     # arrange
-    args = argparse.Namespace
+    args = argparse.Namespace()
     args.directory = ""
     # act
     init(args)
@@ -17,7 +17,7 @@ def test_init_with_no_args():
 
 def test_init_with_current_dir():
     # arrange
-    args = argparse.Namespace
+    args = argparse.Namespace()
     args.directory = "."
     # act
     init(args)
@@ -29,14 +29,13 @@ def test_init_with_current_dir():
 
 
 # def test_serve():
-#     mock_function = create_autospec(serve_results, return_value=None)
-#     # mock serve_results
-#     # mocker.patch("serve_results")
-#     args = argparse.Namespace
-#     args.directory = "."
-#     args.port = 12345
+#     args = argparse.Namespace()
+#     args.directory = "tests_cache"
+#     args.host = "localhost"
+#     args.port = 9876
+#     args.debug = True
 #     serve(args)
-#     mock_function.assert_called_once()
+#     assert False
 
 
 def test_safe_run_command_with_no_args():

--- a/entropylab/results/dashboard/__init__.py
+++ b/entropylab/results/dashboard/__init__.py
@@ -1,12 +1,28 @@
+import logging
+
+from waitress import serve
+
+from entropylab.config import settings
 from entropylab.results.dashboard.dashboard import build_dashboard_app
 from entropylab.results.dashboard.theme import theme_stylesheet
 
 
-def serve_dashboard(path: str, debug: bool):
+def serve_dashboard(path: str, debug: bool = None):
     """Serves our "dashboard" app from dash and opens it in a browser
 
     :param path: The path to the Entropy project to connect to the dashboard
     :param debug: Start the dashboard in debug mode
     """
+    port = settings.get("dashboard.port", 8050)
+    host = settings.get("dashboard.host", "127.0.0.1")
+    log_level = settings.get("dashboard.log_level", logging.INFO)
+    if debug is None:
+        debug = settings.get("dashboard.debug", False)
+
     app = build_dashboard_app(path)
-    app.run_server(debug=debug)
+    app.enable_dev_tools(debug=debug)
+
+    logger = logging.getLogger("waitress")
+    logger.setLevel(log_level)
+
+    serve(app.server, host=host, port=port)

--- a/entropylab/results/dashboard/__init__.py
+++ b/entropylab/results/dashboard/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from waitress import serve
 
@@ -7,22 +8,33 @@ from entropylab.results.dashboard.dashboard import build_dashboard_app
 from entropylab.results.dashboard.theme import theme_stylesheet
 
 
-def serve_dashboard(path: str, debug: bool = None):
-    """Serves our "dashboard" app from dash and opens it in a browser
+def serve_dashboard(
+    path: Optional[str] = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    debug: Optional[bool] = None,
+):
+    """Serves our "dashboard" app using waitress and opens it in a browser.
 
-    :param path: The path to the Entropy project to connect to the dashboard
-    :param debug: Start the dashboard in debug mode
+    :param path: The path to the Entropy project to connect to the dashboard.
+    :param host: The host name from which to server the app. Defaults to "127.0.0.1".
+    :param port: The port name from which to server the app. Defaults to 8050.
+    :param debug: Start the dashboard in debug mode. Defaults to False.
     """
-    port = settings.get("dashboard.port", 8050)
-    host = settings.get("dashboard.host", "127.0.0.1")
-    log_level = settings.get("dashboard.log_level", logging.INFO)
+    if host is None:
+        host = settings.get("dashboard.host", "127.0.0.1")
+    if port is None:
+        port = settings.get("dashboard.port", 8050)
     if debug is None:
         debug = settings.get("dashboard.debug", False)
 
     app = build_dashboard_app(path)
-    app.enable_dev_tools(debug=debug)
 
-    logger = logging.getLogger("waitress")
-    logger.setLevel(log_level)
+    if debug:
+        app.enable_dev_tools(debug=debug)
+        entropy_logger = logging.getLogger("entropy")
+        entropy_logger.setLevel(logging.DEBUG)
+        waitress_logger = logging.getLogger("waitress")
+        waitress_logger.setLevel(logging.DEBUG)
 
     serve(app.server, host=host, port=port)

--- a/poetry.lock
+++ b/poetry.lock
@@ -949,6 +949,18 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "waitress"
+version = "2.0.0"
+description = "Waitress WSGI server"
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.extras]
+docs = ["Sphinx (>=1.8.1)", "docutils", "pylons-sphinx-themes (>=1.0.9)"]
+testing = ["pytest", "pytest-cover", "coverage (>=5.0)"]
+
+[[package]]
 name = "werkzeug"
 version = "2.0.2"
 description = "The comprehensive WSGI web application library."
@@ -974,7 +986,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "f4e91d79729b908baf903020b148c7b413529f7883a1794d987bccafba0f3d1d"
+content-hash = "fa858534b15cba4823990d5c530f71d02c67b42a921a123da691e601b64d39f5"
 
 [metadata.files]
 alembic = [
@@ -1805,6 +1817,10 @@ typing-extensions = [
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
     {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
+]
+waitress = [
+    {file = "waitress-2.0.0-py3-none-any.whl", hash = "sha256:29af5a53e9fb4e158f525367678b50053808ca6c21ba585754c77d790008c746"},
+    {file = "waitress-2.0.0.tar.gz", hash = "sha256:69e1f242c7f80273490d3403c3976f3ac3b26e289856936d1f620ed48f321897"},
 ]
 werkzeug = [
     {file = "Werkzeug-2.0.2-py3-none-any.whl", hash = "sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ alembic = "^1.6.5"
 dynaconf = "^3.1.4"
 dash = "^2.0.0"
 dash-bootstrap-components = "^1.0.0"
+waitress = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"


### PR DESCRIPTION
This PR resolves issue https://github.com/entropy-lab/entropy/issues/107.

Instead of using Dash's built-in Flask server, our dashboard app now serves its content using [waitress](https://docs.pylonsproject.org/projects/waitress/en/latest/index.html), a production-grade WSGI server written in Python.

4 new config settings have been added to support this:
- `HOST` defaults to `127.0.0.1`.
- `PORT` defaults to `8050`.
- `LOG_LEVEL` (specific to waitress) defaults to `INFO`.
- `DEBUG` (to enable Dash debugging features), defaults to `False`.
