### PR TITLE
Using Interval component to refresh exp table every 3 secs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New results dashboard web application
 * Dashboard: Auto plot last result
 * Dashboard: Serve using production-grade WSGI server (waitress 2.0.0)
+* Dashboard: Experiments table is refreshed from disk every 3 seconds
 
 ## [0.3.0] - 2021-10-11
 ### Added

--- a/entropylab/results/dashboard/dashboard_data.py
+++ b/entropylab/results/dashboard/dashboard_data.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List
+from typing import List, Dict
 
 # import numpy as np
 from pandas import DataFrame
@@ -24,8 +24,13 @@ class SqlalchemyDashboardDataReader(DashboardDataReader):
         super().__init__()
         self._db: SqlAlchemyDB = connector
 
-    def get_last_experiments(self, number) -> DataFrame:
-        return self._db.get_last_experiments(number)
+    def get_last_experiments(self, max_num_of_experiments: int) -> List[Dict]:
+        experiments = self._db.get_last_experiments(max_num_of_experiments)
+        experiments["success"] = experiments["success"].apply(
+            lambda x: "✔️" if x else "❌"
+        )
+        records = experiments.to_dict("records")
+        return records
 
     def get_last_result_of_experiment(self, experiment_id):
         return self._db.get_last_result_of_experiment(experiment_id)

--- a/entropylab/results/dashboard/layout.py
+++ b/entropylab/results/dashboard/layout.py
@@ -1,3 +1,5 @@
+from typing import List, Dict
+
 import dash_bootstrap_components as dbc
 from dash import html, dcc
 
@@ -5,12 +7,15 @@ from entropylab.results.dashboard.table import table
 from entropylab.results_backend.sqlalchemy.project import project_name, project_path
 
 
-def layout(path: str, records: dict):
+def layout(path: str, records: List[Dict]):
     return dbc.Container(
         className="main",
         children=[
             dcc.Store(id="plot-figures", storage_type="session"),
             dcc.Store(id="plot-keys-to-combine", storage_type="session"),
+            dcc.Interval(
+                id="interval", interval=3 * 1000, n_intervals=0  # in milliseconds
+            ),
             dbc.Row(
                 dbc.Navbar(
                     dbc.Container(


### PR DESCRIPTION
This PR implements issue https://github.com/entropy-lab/entropy/issues/102.

The dashboard now reloads the data for the experiment table every 3 seconds. This is done using a [Dash Interval component](https://dash.plotly.com/live-updates#the-dcc.interval-component).

Acceptance test:
1. Run `entropy serve` on an Entropy project.
2. Open the dashboard in a browser
3. Open the sqlite database and make changes to the `Experiments` table.
4. Verify that the dashboard reflects the changes in the experiments table without you having to reload the page.