### PR TITLE
Copy to clipboard button added to Aggregate tab

### DIFF
--- a/entropylab/results/dashboard/assets/dashboard.css
+++ b/entropylab/results/dashboard/assets/dashboard.css
@@ -86,7 +86,7 @@ input.current-page::placeholder {
 .tab-content {
   width:100%;
   min-height:400px !important;
-  background-color: #333333;
+  background-color: rgb(var(--bs-dark-rgb)); /*#333333;*/
 }
 
 .tab-placeholder-container {
@@ -147,4 +147,19 @@ input.current-page::placeholder {
   right: 20px;
   z-index: 100;
   opacity: 95%;
+}
+
+#aggregate-container {
+  position: relative;
+}
+
+#aggregate-tabs .nav-item {
+  width:154px;
+}
+
+#copy-data-button {
+  position: absolute;
+  top: 3px;
+  left: 240px;
+  font-size:12px;
 }

--- a/entropylab/results/dashboard/dashboard_data.py
+++ b/entropylab/results/dashboard/dashboard_data.py
@@ -48,7 +48,7 @@ class SqlalchemyDashboardDataReader(DashboardDataReader):
             return plots
         else:
             last_result = self._db.get_last_result_of_experiment(exp_id)
-            if last_result and last_result.data:
+            if last_result is not None and last_result.data is not None:
                 plot = auto_plot(exp_id, last_result.data)
                 return [plot]
             else:

--- a/entropylab/results/dashboard/layout.py
+++ b/entropylab/results/dashboard/layout.py
@@ -127,17 +127,33 @@ def layout(path: str, records: List[Dict]):
                         className="add-button-col",
                     ),
                     dbc.Col(
-                        dbc.Tabs(
-                            id="aggregate-tabs",
-                            children=[
-                                dbc.Tab(
-                                    "",
-                                    label="Aggregate",
-                                    id="aggregate-tab",
-                                )
-                            ],
-                            persistence=True,
-                        ),
+                        [
+                            dbc.Tabs(
+                                id="aggregate-tabs",
+                                children=[
+                                    dbc.Tab(
+                                        "",
+                                        label="Aggregate",
+                                        id="aggregate-tab",
+                                    )
+                                ],
+                                persistence=True,
+                            ),
+                            dbc.Button(
+                                [
+                                    "Copy Data to Clipboard",
+                                    dcc.Clipboard(
+                                        title="Copy data to clipboard",
+                                        id="aggregate-clipboard",
+                                        className="position-absolute start-0 top-0 "
+                                        "h-100 w-100 opacity-0",
+                                    ),
+                                ],
+                                id="copy-data-button",
+                                color="primary",
+                            ),
+                        ],
+                        id="aggregate-container",
                         width="5",
                     ),
                     dbc.Col(

--- a/entropylab/results/dashboard/tests/test_dashboard.py
+++ b/entropylab/results/dashboard/tests/test_dashboard.py
@@ -1,0 +1,58 @@
+import numpy
+import numpy as np
+from plotly import graph_objects as go
+
+from entropylab.results.dashboard.dashboard import (
+    _copy_aggregate_data_to_clipboard_as_python_code,
+)
+
+
+def test_copy_aggregate_data_to_clipboard_as_python_code_empty_figure():
+    figure = go.Figure()
+    actual = _copy_aggregate_data_to_clipboard_as_python_code(None, figure.to_dict())
+    data = eval(actual.replace("data = ", ""))
+    assert data == []
+
+
+def test_copy_aggregate_data_to_clipboard_as_python_code_empty_values():
+    figure = dict(data=[dict(name="", x=[], y=[])])
+    actual = _copy_aggregate_data_to_clipboard_as_python_code(None, figure)
+    data = eval(actual.replace("data = ", ""))
+    assert data is not None
+    assert data[0][""]["x"] == []
+    assert data[0][""]["y"] == []
+
+
+def test_copy_aggregate_data_to_clipboard_as_python_code_arrays():
+    figure = go.Figure()
+    figure.add_trace(
+        go.Scatter(
+            mode="lines",
+            name="test",
+            x=[0, 1, 2, 3, 4],
+            y=[5, 6, 7, 8, 9],
+        )
+    )
+    actual = _copy_aggregate_data_to_clipboard_as_python_code(None, figure.to_dict())
+    # assert actual == "data = [{'test': {'x': [0, 1, 2, 3, 4], 'y': [0, 1, 2, 3, 4]}}]"
+    data = eval(actual.replace("data = ", ""))
+    assert data is not None
+    assert data[0]["test"]["x"] == [0, 1, 2, 3, 4]
+    assert data[0]["test"]["y"] == [5, 6, 7, 8, 9]
+
+
+def test_copy_aggregate_data_to_clipboard_as_python_code_ndarrays():
+    figure = go.Figure()
+    figure.add_trace(
+        go.Scatter(
+            mode="lines",
+            name="test",
+            x=np.arange(5),
+            y=np.arange(5, 10),
+        )
+    )
+    actual = _copy_aggregate_data_to_clipboard_as_python_code(None, figure.to_dict())
+    data = eval(actual.replace("data = ", ""), {"np": numpy})
+    assert data is not None
+    assert data[0]["test"]["x"].tolist() == [0, 1, 2, 3, 4]
+    assert data[0]["test"]["y"].tolist() == [5, 6, 7, 8, 9]


### PR DESCRIPTION
This PR implements https://github.com/entropy-lab/entropy/issues/113.

A button is added to the aggregate tab. Clicking on the button generates python code from the data of any figures shown in the tab and copies to the clipboard. Users can then paste the code into their development / research work environment.