### PR TITLE
Showing modal if experiments table is empty

### DIFF
--- a/entropylab/results/dashboard/assets/dashboard.css
+++ b/entropylab/results/dashboard/assets/dashboard.css
@@ -126,6 +126,10 @@ input.current-page::placeholder {
   border-color: #999999;
 }
 
+.modal-backdrop.show {
+  opacity: 0.8;
+}
+
 #failed-plotting-alert {
   position: absolute;
   top: 20px;

--- a/entropylab/results/dashboard/layout.py
+++ b/entropylab/results/dashboard/layout.py
@@ -25,6 +25,25 @@ def layout(path: str, records: List[Dict]):
                 fade=True,
                 # duration=3000,
             ),
+            dbc.Modal(
+                [
+                    dbc.ModalHeader(
+                        dbc.ModalTitle(
+                            f"ℹ️ Project '{project_name(path)}' contains no experiments"
+                        ),
+                        close_button=False,
+                    ),
+                    dbc.ModalBody(
+                        "As soon as experiments are saved to the project this notice "
+                        "will be closed and the experiments will be shown below."
+                    ),
+                    dbc.ModalFooter(),
+                ],
+                id="empty-project-modal",
+                backdrop="static",
+                centered=True,
+                is_open=False,
+            ),
             dbc.Row(
                 dbc.Navbar(
                     [


### PR DESCRIPTION
This PR aims to resolve issue https://github.com/entropy-lab/entropy/issues/100

When a project that contains no experiments is loaded in the dashboard a modal is shown in the center of the window and all other UI elements are covered with an opaque layer as shown below. Once experiments are saved into the project the modal is removed and the experiments are loaded into the dashboard UI.

![image](https://user-images.githubusercontent.com/350687/147413793-9976a9b8-9ff5-4c2f-bf7e-928fe3fd9a1c.png)
