### PR TITLE
Show a vertical spacer if there's only 1 page of experiments

### DIFF
--- a/entropylab/results/dashboard/assets/dashboard.css
+++ b/entropylab/results/dashboard/assets/dashboard.css
@@ -53,6 +53,10 @@ input.current-page::placeholder {
   color: var(--bs-body-color) !important;
 }
 
+#no-paging-spacer {
+  height:40px
+}
+
 /* Tab colors */
 .nav .nav-item .active.nav-link {
   background-color: rgb(var(--bs-dark-rgb)) !important;

--- a/entropylab/results/dashboard/dashboard.py
+++ b/entropylab/results/dashboard/dashboard.py
@@ -54,6 +54,7 @@ def build_dashboard_app(proj_path):
     @_app.callback(
         Output("plot-tabs", "children"),
         Output("plot-figures", "data"),
+        Output("no-paging-spacer", "hidden"),
         Input("experiments-table", "selected_rows"),
         State("experiments-table", "data"),
         State("plot-figures", "data"),
@@ -64,6 +65,7 @@ def build_dashboard_app(proj_path):
         plot_figures = plot_figures or {}
         result = []
         failed_exp_ids = []
+        spacer_hidden = len(data) > EXPERIMENTS_PAGE_SIZE
         if selected_rows:
             for row_num in selected_rows:
                 exp_id = data[row_num]["id"]
@@ -82,9 +84,9 @@ def build_dashboard_app(proj_path):
                     failed_exp_ids.append(exp_id)
         # TODO: Show notification to user that exp cannot be plotted (failed_exp_ids)
         if len(result) > 0:
-            return result, plot_figures
+            return result, plot_figures, spacer_hidden
         else:
-            return [build_plot_tabs_placeholder()], plot_figures
+            return [build_plot_tabs_placeholder()], plot_figures, spacer_hidden
 
     def build_plot_tabs_placeholder():
         return dbc.Tab(

--- a/entropylab/results/dashboard/layout.py
+++ b/entropylab/results/dashboard/layout.py
@@ -49,7 +49,11 @@ def layout(path: str, records: List[Dict]):
             ),
             dbc.Row(
                 dbc.Col(
-                    [html.H5("Experiments", id="experiments-title"), (table(records))],
+                    [
+                        html.H5("Experiments", id="experiments-title"),
+                        (table(records)),
+                        html.Div(id="no-paging-spacer"),
+                    ],
                     width="12",
                 )
             ),


### PR DESCRIPTION
This PR resolves issue https://github.com/entropy-lab/entropy/issues/137.

When the dashboard shows 6 experiments or less the paging control for the experiments table are not shown. This PR adds a vertical spacer (`<div>`) in this case. If there are more than 6 experiments the spacer is hidden,