### PR TITLE
get_last_result_of_experiment() now uses storage by default

### DIFF
--- a/entropylab/results_backend/sqlalchemy/db.py
+++ b/entropylab/results_backend/sqlalchemy/db.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.sql import Selectable
 from sqlalchemy.util.compat import contextmanager
 
-from entropylab.config import settings
 from entropylab.api.data_reader import (
     DataReader,
     ExperimentRecord,
@@ -31,6 +30,7 @@ from entropylab.api.data_writer import (
     PlotSpec,
     NodeData,
 )
+from entropylab.config import settings
 from entropylab.instruments.instrument_driver import Function, Parameter
 from entropylab.instruments.lab_topology import (
     PersistentLabDB,
@@ -282,6 +282,14 @@ class SqlAlchemyDB(DataWriter, DataReader, PersistentLabDB):
         return []
 
     def get_last_result_of_experiment(
+        self, experiment_id: int
+    ) -> Optional[ResultRecord]:
+        if self.__hdf5_storage_enabled():
+            return self._storage.get_last_result_of_experiment(experiment_id)
+        else:
+            return self.__get_last_result_of_experiment_from_sqlalchemy(experiment_id)
+
+    def __get_last_result_of_experiment_from_sqlalchemy(
         self, experiment_id: int
     ) -> Optional[ResultRecord]:
         with self._session_maker() as sess:

--- a/entropylab/results_backend/sqlalchemy/tests/test_db.py
+++ b/entropylab/results_backend/sqlalchemy/tests/test_db.py
@@ -11,3 +11,27 @@ def test_save_result_raises_when_same_result_saved_twice(initialized_project_dir
     with pytest.raises(ValueError):
         # act & assert
         db.save_result(0, raw_result)
+
+
+def test_get_last_result_of_experiment_works_with_storage(initialized_project_dir_path):
+    # arrange
+    db = SqlAlchemyDB(initialized_project_dir_path, enable_hdf5_storage=False)
+    db.save_result(1, RawResultData(label="save", data="to db"))
+    db = SqlAlchemyDB(initialized_project_dir_path, enable_hdf5_storage=True)
+    db.save_result(1, RawResultData(label="save", data="to storage"))
+    # act
+    actual = db.get_last_result_of_experiment(1)
+    # assert
+    assert actual.data == "to storage"
+
+
+def test_get_last_result_of_experiment_works_with_db(initialized_project_dir_path):
+    # arrange
+    db = SqlAlchemyDB(initialized_project_dir_path, enable_hdf5_storage=True)
+    db.save_result(1, RawResultData(label="save", data="to storage"))
+    db = SqlAlchemyDB(initialized_project_dir_path, enable_hdf5_storage=False)
+    db.save_result(1, RawResultData(label="save", data="to db"))
+    # act
+    actual = db.get_last_result_of_experiment(1)
+    # assert
+    assert actual.data == "to db"


### PR DESCRIPTION
This PR resolves issue https://github.com/entropy-lab/entropy/issues/121 by adapting the SqlAlchemyDB method `get_last_result_of_experiment()` to read the result from the HDF5 storage file (subject to configuration).