### PR TITLE
In-process ParamStore

### DIFF
--- a/entropylab/api/param_store.py
+++ b/entropylab/api/param_store.py
@@ -3,9 +3,12 @@ import json
 from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum, unique
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 
-from tinydb import TinyDB
+from tinydb import TinyDB, Query
+from tinydb.storages import MemoryStorage
+
+from entropylab.api.errors import EntropyError
 
 
 @unique
@@ -54,10 +57,21 @@ class ParamStore(ABC):
 
 
 class InProcessParamStore(ParamStore):
-    def __init__(self):
+
+    """Naive implementation of ParamStore based on tinydb
+
+    Important:
+    Using this implementation in multiple concurrent processes is not supported.
+    """
+
+    # TODO: Use path to entropy project instead of direct path to tinydb file?
+    def __init__(self, path: Optional[str] = None):
         super().__init__()
         self._dict = dict()
-        self._db = TinyDB()
+        if path is None:
+            self._db = TinyDB(storage=MemoryStorage)
+        else:
+            self._db = TinyDB(path)
 
     """ Present dictionary """
 
@@ -67,18 +81,40 @@ class InProcessParamStore(ParamStore):
     def __getitem__(self, key: str) -> Any:
         return self._dict[key]
 
+    def __contains__(self, key: str) -> bool:
+        return key in self._dict
+
     def to_dict(self) -> Dict:
         return dict(self._dict)
 
     """ Commits """
 
     def commit(self) -> str:
-        commit_id = self._generate_id()
+        commit_id = self._hash_dict()
+        # TODO: Protect against commit the same hash twice:
         self._db.insert({"_id": commit_id} | self._dict)
         return commit_id
 
-    def _generate_id(self):
+    def checkout(self, commit_id: str):
+        commit_dict = self._get_commit_dict(commit_id)
+        self._dict = commit_dict
+
+    def _hash_dict(self):
         dict_as_string = json.dumps(
             self._dict, sort_keys=True, ensure_ascii=True
         ).encode("utf-8")
         return hashlib.sha1(dict_as_string).hexdigest()
+
+    def _get_commit_dict(self, commit_id: str) -> Dict:
+        query = Query()
+        # noinspection PyProtectedMember
+        result = self._db.search(query._id == commit_id)
+        if len(result) == 0:
+            raise EntropyError(f"Commit with id '{commit_id}' not found")
+        if len(result) == 0:
+            raise EntropyError(
+                f"{len(result)} commits with id '{commit_id}' found. "
+                f"Only one commit is allowed per id"
+            )
+        del result[0]["_id"]
+        return result[0]

--- a/entropylab/api/param_store.py
+++ b/entropylab/api/param_store.py
@@ -1,0 +1,84 @@
+import hashlib
+import json
+from abc import ABC, abstractmethod
+from datetime import datetime
+from enum import Enum, unique
+from typing import Dict, List, Any
+
+from tinydb import TinyDB
+
+
+@unique
+class MergeStrategy(Enum):
+    OURS = (1,)
+    THEIRS = (2,)
+    RECURSIVE = 3
+
+
+class Commit:
+    id: str
+    datetime: datetime
+
+
+class ParamStore(ABC):
+    def __init__(self):
+        super().__init__()
+
+    """ Present dictionary """
+
+    @abstractmethod
+    def __getitem__(self, key: str) -> Any:
+        pass
+
+    @abstractmethod
+    def __setitem__(self, key: str, value: Any) -> None:
+        pass
+
+    @abstractmethod
+    def commit(self) -> str:
+        pass
+
+    @abstractmethod
+    def to_dict(self) -> Dict:
+        pass
+
+    # def merge(
+    #     self,
+    #     theirs: ParamStore,
+    #     merge_strategy: Optional[MergeStrategy] = MergeStrategy.OURS,
+    # ) -> None:
+    #     pass
+
+    def search_for_label(self, label: str) -> List[Commit]:
+        pass
+
+
+class InProcessParamStore(ParamStore):
+    def __init__(self):
+        super().__init__()
+        self._dict = dict()
+        self._db = TinyDB()
+
+    """ Present dictionary """
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._dict[key] = value
+
+    def __getitem__(self, key: str) -> Any:
+        return self._dict[key]
+
+    def to_dict(self) -> Dict:
+        return dict(self._dict)
+
+    """ Commits """
+
+    def commit(self) -> str:
+        commit_id = self._generate_id()
+        self._db.insert({"_id": commit_id} | self._dict)
+        return commit_id
+
+    def _generate_id(self):
+        dict_as_string = json.dumps(
+            self._dict, sort_keys=True, ensure_ascii=True
+        ).encode("utf-8")
+        return hashlib.sha1(dict_as_string).hexdigest()

--- a/entropylab/api/param_store.py
+++ b/entropylab/api/param_store.py
@@ -22,6 +22,14 @@ class Header:
     id: str
     ns: int
 
+    def __repr__(self) -> str:
+        return json.dumps(
+            self, default=lambda o: o.__dict__, sort_keys=True, ensure_ascii=True
+        )
+
+    def to_dict(self) -> dict:
+        return dict(id=self.id, ns=self.ns)
+
 
 class ParamStore(ABC):
     def __init__(self):
@@ -67,22 +75,48 @@ class InProcessParamStore(ParamStore):
     # TODO: Use path to entropy project instead of direct path to tinydb file?
     def __init__(self, path: Optional[str] = None):
         super().__init__()
+        self._is_dirty = True  # were params modified since commit() / checkout()?
+        self._base_commit_id = None  # id of last commit checked out/committed
         self._body = dict()
         if path is None:
             self._db = TinyDB(storage=MemoryStorage)
         else:
             self._db = TinyDB(path)
 
-    """ Present dictionary """
+    """ Attributes """
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            super().__setattr__(name, value)
+        else:
+            self._body[name] = value
+            self._is_dirty = True
+
+    def __getattr__(self, name):
+        if name.startswith("_"):
+            return super().__getattribute__(name)
+        else:
+            return self._body[name]
+
+    def __delattr__(self, name):
+        if name.startswith("_"):
+            super().__delattr__(name)
+        else:
+            del self._body[name]
+            self._is_dirty = True
+
+    """ Items """
 
     def __setitem__(self, key: str, value: Any) -> None:
         self._body[key] = value
+        self._is_dirty = True
 
     def __getitem__(self, key: str) -> Any:
         return self._body[key]
 
     def __delitem__(self, *args, **kwargs):
         self._body.__delitem__(*args, **kwargs)
+        self._is_dirty = True
 
     def __contains__(self, key: str) -> bool:
         return key in self._body
@@ -100,24 +134,27 @@ class InProcessParamStore(ParamStore):
     """ Commits """
 
     def commit(self) -> str:
-        id = self._hash_dict()
-        if self._db.contains(Query().header.id == id):
-            # TODO: log a warning?
-            return id
-        else:
-            header = dict(id=id, ns=time.time_ns())
-            self._db.insert(dict(header=header, body=self._body))
-            return header["id"]
+        if not self._is_dirty:
+            return self._base_commit_id
+        header = self._generate_header()
+        self._db.insert(dict(header=header.to_dict(), body=self._body))
+        self._base_commit_id = header.id
+        self._is_dirty = False
+        return header.id
 
     def checkout(self, commit_id: str):
         commit_dict = self._get_commit_body(commit_id)
         self._body = commit_dict
+        self._base_commit_id = commit_id
+        self._is_dirty = False
 
-    def _hash_dict(self):
-        dict_as_string = json.dumps(
-            self._body, sort_keys=True, ensure_ascii=True
-        ).encode("utf-8")
-        return hashlib.sha1(dict_as_string).hexdigest()
+    def _generate_header(self) -> (str, int):
+        header = Header()
+        header.ns = time.time_ns()
+        jzon = json.dumps(self._body, sort_keys=True, ensure_ascii=True)
+        bytez = (jzon + str(header.ns)).encode("utf-8")
+        header.id = hashlib.sha1(bytez).hexdigest()
+        return header
 
     def _get_commit_body(self, commit_id: str) -> Dict:
         query = Query()

--- a/entropylab/api/param_store.py
+++ b/entropylab/api/param_store.py
@@ -32,11 +32,12 @@ class Metadata:
             self.__dict__.update(dikt)
 
     def __repr__(self) -> str:
-        date = pd.to_datetime(self.ns).to_pydatetime()
-        return f"<Metadata(id='{self.id}', ns='{date}', label='{self.label}')>"
-        # return json.dumps(
-        #     self, default=lambda o: o.__dict__, sort_keys=True, ensure_ascii=True
-        # )
+        d = self.__dict__.copy()
+        d["ns"] = str(pd.to_datetime(self.ns).to_pydatetime())
+        jzon = json.dumps(
+            d, default=lambda o: o.__dict__, sort_keys=True, ensure_ascii=True
+        )
+        return f"<Metadata({jzon})>"
 
 
 class ParamStore(ABC):

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -72,7 +72,7 @@ def test_commit_when_committing_same_state_twice_a_different_id_is_returned(
 """ checkout() """
 
 
-def test_checkout_and_id_removed_from_dict(tinydb_file_path):
+def test_checkout_when_commit_id_exists_value_is_reverted(tinydb_file_path):
     # arrange
     target = InProcessParamStore(tinydb_file_path)
     target["foo"] = "bar"
@@ -82,20 +82,41 @@ def test_checkout_and_id_removed_from_dict(tinydb_file_path):
     target.checkout(commit_id)
     # assert
     assert target["foo"] == "bar"
-    assert "_id" not in target
 
 
-""" _generate_header() """
+def test_checkout_when_commit_id_exists_value_remains_the_same(tinydb_file_path):
+    # arrange
+    target = InProcessParamStore(tinydb_file_path)
+    target["foo"] = "bar"
+    commit_id = target.commit()
+    # act
+    target.checkout(commit_id)
+    # assert
+    assert target["foo"] == "bar"
 
 
-def test__generate_header_empty_dict():
+def test_checkout_when_commit_id_exists_value_is_removed(tinydb_file_path):
+    # arrange
+    target = InProcessParamStore(tinydb_file_path)
+    commit_id = target.commit()
+    target["foo"] = "baz"
+    # act
+    target.checkout(commit_id)
+    # assert
+    assert "foo" not in target
+
+
+""" _generate_metadata() """
+
+
+def test__generate_metadata_empty_dict():
     target = InProcessParamStore()
-    actual = target._generate_header()
+    actual = target._generate_metadata()
     assert len(actual.id) == 40
 
 
-def test__generate_header_nonempty_dict():
+def test__generate_metadata_nonempty_dict():
     target = InProcessParamStore()
     target["foo"] = "bar"
-    actual = target._generate_header()
+    actual = target._generate_metadata()
     assert len(actual.id) == 40

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -1,0 +1,23 @@
+from entropylab.api.param_store import InProcessParamStore
+
+
+def test_in_process_set_and_get():
+    target = InProcessParamStore()
+    target["foo"] = "bar"
+    assert target["foo"] == "bar"
+
+
+def test_commit_empty_dict():
+    target = InProcessParamStore()
+    assert target.commit == "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+
+
+def test__generate_id_empty_dict():
+    target = InProcessParamStore()
+    assert target._generate_id() == "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+
+
+def test__generate_id_nonempty_dict():
+    target = InProcessParamStore()
+    target["foo"] = "bar"
+    assert target._generate_id() == "bc4919c6adf7168088eaea06e27a5b23f0f9f9da"

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -28,9 +28,33 @@ def test_get_when_key_is_none_then_keyerror_is_raised():
 """ commit() """
 
 
-def test_commit_empty_dict(tinydb_file_path):
+def test_commit_when_body_is_empty_does_not_throw(tinydb_file_path):
     target = InProcessParamStore(tinydb_file_path)
     assert target.commit() == "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+
+
+def test_commit_when_committing_twice_the_same_id_is_returned(tinydb_file_path):
+    target = InProcessParamStore(tinydb_file_path)
+    first = target.commit()
+    second = target.commit()
+    assert first == second
+
+
+def test_commit_when_committing_same_state_twice_the_same_id_is_returned(
+    tinydb_file_path,
+):
+    # arrange
+    target = InProcessParamStore(tinydb_file_path)
+    target["foo"] = "bar"
+    first = target.commit()
+    del target["foo"]
+    # noinspection PyUnusedLocal
+    second = target.commit()
+    target["foo"] = "bar"
+    # act
+    third = target.commit()
+    # assert
+    assert first == third
 
 
 """ checkout() """

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -1,4 +1,5 @@
 import pytest
+from tinydb import Query
 
 from entropylab.api.param_store import InProcessParamStore
 
@@ -67,6 +68,20 @@ def test_commit_when_committing_same_state_twice_a_different_id_is_returned(
     third = target.commit()
     # assert
     assert first != third
+
+
+def test_commit_when_label_is_not_given_then_null_is_saved(tinydb_file_path):
+    target = InProcessParamStore(tinydb_file_path)
+    commit_id = target.commit()
+    result = target._db.search(Query().metadata.id == commit_id)
+    assert result[0]["metadata"]["label"] is None
+
+
+def test_commit_when_label_is_given_then_label_is_saved(tinydb_file_path):
+    target = InProcessParamStore(tinydb_file_path)
+    commit_id = target.commit("foo")
+    result = target._db.search(Query().metadata.id == commit_id)
+    assert result[0]["metadata"]["label"] == "foo"
 
 
 """ checkout() """

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -6,6 +6,14 @@ from tinydb import Query
 from entropylab.api.errors import EntropyError
 from entropylab.api.param_store import InProcessParamStore, Metadata, MergeStrategy
 
+""" ctor """
+
+
+def test_ctor_is_dirty_is_true():
+    target = InProcessParamStore()
+    assert target.is_dirty is True
+
+
 """ __getitem()__"""
 
 
@@ -184,10 +192,10 @@ def test_checkout_when_move_by_exists_value_is_reverted(
     assert target["val"] == expected_val
 
 
-""" log() """
+""" list_commits() """
 
 
-def test_log_no_args_returns_all_metadata(
+def test_list_commits_no_args_returns_all_metadata(
     tinydb_file_path,
 ):
     # arrange
@@ -199,7 +207,7 @@ def test_log_no_args_returns_all_metadata(
     target["foo"] = "buzz"
     target.commit("third")
     # act
-    actual = target.log()
+    actual = target.list_commits()
     # assert
     assert all(type(m) == Metadata for m in actual)
     assert actual[0].label == "first"
@@ -207,7 +215,7 @@ def test_log_no_args_returns_all_metadata(
     assert actual[2].label == "third"
 
 
-def test_log_when_label_exists_then_it_is_returned(
+def test_list_commits_when_label_exists_then_it_is_returned(
     tinydb_file_path,
 ):
     # arrange
@@ -225,7 +233,7 @@ def test_log_when_label_exists_then_it_is_returned(
     target["foo"] = "None"
     target.commit()
     # act
-    actual = target.log("label")
+    actual = target.list_commits("label")
     # assert
     assert all(type(m) == Metadata for m in actual)
     assert all("label" in m.label for m in actual)
@@ -414,8 +422,8 @@ def test_demo(tinydb_file_path):
 
     print(f"checked out freq: {target['qubit1.flux_capacitor.freq']}")
 
-    print("log commits labeled 'warm': ")
-    pprint(target.log("warm"))
+    print("list_commits commits labeled 'warm': ")
+    pprint(target.list_commits("warm"))
 
     print("all params: ")
     pprint(target.to_dict())

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -5,6 +5,18 @@ from entropylab.api.param_store import InProcessParamStore
 """ __getitem()__"""
 
 
+def test___getattribute_works():
+    target = InProcessParamStore()
+    target["foo"] = "bar"
+    assert target.foo == "bar"
+
+
+def test___setattr_works():
+    target = InProcessParamStore()
+    target.foo = "bar"
+    assert target["foo"] == "bar"
+
+
 def test_get_when_key_is_present_then_value_is_returned():
     target = InProcessParamStore()
     target["foo"] = "bar"
@@ -30,17 +42,17 @@ def test_get_when_key_is_none_then_keyerror_is_raised():
 
 def test_commit_when_body_is_empty_does_not_throw(tinydb_file_path):
     target = InProcessParamStore(tinydb_file_path)
-    assert target.commit() == "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+    assert len(target.commit()) == 40
 
 
-def test_commit_when_committing_twice_the_same_id_is_returned(tinydb_file_path):
+def test_commit_when_committing_non_dirty_does_nothing(tinydb_file_path):
     target = InProcessParamStore(tinydb_file_path)
     first = target.commit()
     second = target.commit()
     assert first == second
 
 
-def test_commit_when_committing_same_state_twice_the_same_id_is_returned(
+def test_commit_when_committing_same_state_twice_a_different_id_is_returned(
     tinydb_file_path,
 ):
     # arrange
@@ -54,7 +66,7 @@ def test_commit_when_committing_same_state_twice_the_same_id_is_returned(
     # act
     third = target.commit()
     # assert
-    assert first == third
+    assert first != third
 
 
 """ checkout() """
@@ -73,15 +85,17 @@ def test_checkout_and_id_removed_from_dict(tinydb_file_path):
     assert "_id" not in target
 
 
-""" _hash_dict() """
+""" _generate_header() """
 
 
-def test__hash_dict_empty_dict():
+def test__generate_header_empty_dict():
     target = InProcessParamStore()
-    assert target._hash_dict() == "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+    actual = target._generate_header()
+    assert len(actual.id) == 40
 
 
-def test__hash_dict_nonempty_dict():
+def test__generate_header_nonempty_dict():
     target = InProcessParamStore()
     target["foo"] = "bar"
-    assert target._hash_dict() == "bc4919c6adf7168088eaea06e27a5b23f0f9f9da"
+    actual = target._generate_header()
+    assert len(actual.id) == 40

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -1,3 +1,5 @@
+from pprint import pprint
+
 import pytest
 from tinydb import Query
 
@@ -183,3 +185,35 @@ def test__generate_metadata_nonempty_dict():
     target["foo"] = "bar"
     actual = target._generate_metadata()
     assert len(actual.id) == 40
+
+
+def test_demo(tinydb_file_path):
+    target = InProcessParamStore(tinydb_file_path)
+    target["qubit1.flux_capacitor.freq"] = 8.0
+    target["qubit1.flux_capacitor.amp"] = 5.0
+    target["qubit1.flux_capacitor"] = {"wave": "manifold", "warp": 1337.0}
+
+    print(f"before commit freq: {target['qubit1.flux_capacitor.freq']}")
+
+    commit_id1 = target.commit("warm-up")
+
+    print(f"first commit freq: {target['qubit1.flux_capacitor.freq']}")
+
+    target["qubit1.flux_capacitor.freq"] = 11.0
+
+    print(f"second commit freq: {target['qubit1.flux_capacitor.freq']}")
+    print(
+        f"first commit freq from history: {target.get('qubit1.flux_capacitor.freq', commit_id1)}"
+    )
+
+    commit_id2 = target.commit("warm-up")
+
+    target.checkout(commit_id1)
+
+    print(f"checked out freq: {target['qubit1.flux_capacitor.freq']}")
+
+    print("log commits labeled 'warm': ")
+    pprint(target.log("warm"))
+
+    print("all params: ")
+    pprint(target.to_dict())

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -1,23 +1,63 @@
+import pytest
+
 from entropylab.api.param_store import InProcessParamStore
 
+""" __getitem()__"""
 
-def test_in_process_set_and_get():
+
+def test_get_when_key_is_present_then_value_is_returned():
     target = InProcessParamStore()
     target["foo"] = "bar"
     assert target["foo"] == "bar"
 
 
-def test_commit_empty_dict():
+def test_get_when_key_is_missing_then_keyerror_is_raised():
     target = InProcessParamStore()
-    assert target.commit == "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+    with pytest.raises(KeyError):
+        # noinspection PyStatementEffect
+        target["foo"]
 
 
-def test__generate_id_empty_dict():
+def test_get_when_key_is_none_then_keyerror_is_raised():
     target = InProcessParamStore()
-    assert target._generate_id() == "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+    with pytest.raises(KeyError):
+        # noinspection PyTypeChecker,PyStatementEffect
+        target[None]
 
 
-def test__generate_id_nonempty_dict():
+""" commit() """
+
+
+def test_commit_empty_dict(tinydb_file_path):
+    target = InProcessParamStore(tinydb_file_path)
+    assert target.commit() == "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+
+
+""" checkout() """
+
+
+def test_checkout_and_id_removed_from_dict(tinydb_file_path):
+    # arrange
+    target = InProcessParamStore(tinydb_file_path)
+    target["foo"] = "bar"
+    commit_id = target.commit()
+    target["foo"] = "baz"
+    # act
+    target.checkout(commit_id)
+    # assert
+    assert target["foo"] == "bar"
+    assert "_id" not in target
+
+
+""" _hash_dict() """
+
+
+def test__hash_dict_empty_dict():
+    target = InProcessParamStore()
+    assert target._hash_dict() == "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
+
+
+def test__hash_dict_nonempty_dict():
     target = InProcessParamStore()
     target["foo"] = "bar"
-    assert target._generate_id() == "bc4919c6adf7168088eaea06e27a5b23f0f9f9da"
+    assert target._hash_dict() == "bc4919c6adf7168088eaea06e27a5b23f0f9f9da"

--- a/entropylab/conftest.py
+++ b/entropylab/conftest.py
@@ -40,6 +40,15 @@ def db_file_path(request) -> str:
 
 
 @pytest.fixture()
+def tinydb_file_path(request) -> str:
+    """Generate a unique path to a (non-existent) tinydb json file
+    The file will be removed on tear down"""
+    file_path = _build_project_dir_path_for_test(request) + ".json"
+    yield file_path
+    _delete_if_exists(file_path)
+
+
+@pytest.fixture()
 def initialized_project_dir_path(request, project_dir_path) -> str:
     """Create an initialized project and return the path to its directory
     The directory will be removed recursively on tear down"""

--- a/entropylab/conftest.py
+++ b/entropylab/conftest.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
@@ -68,13 +69,17 @@ def _build_project_dir_path_for_test(request):
     project_dir_path = (
         f"tests_cache/{request.node.name}_{datetime.now():%Y-%m-%d-%H-%M-%S}"
     )
+    Path("tests_cache").mkdir(parents=True, exist_ok=True)
     return project_dir_path
 
 
-def _delete_if_exists(directory: str):
-    if os.path.isdir(directory):
-        logger.debug(f"Deleting test project directory '{directory}'")
-        shutil.rmtree(directory)
+def _delete_if_exists(path: str):
+    if os.path.isdir(path):
+        logger.debug(f"Test cleanup. Deleting directory '{path}'")
+        shutil.rmtree(path)
+    elif os.path.isfile(path):
+        logger.debug(f"Test cleanup. Deleting file '{path}'")
+        os.remove(path)
 
 
 def _copy_db_template(src, dst, request):

--- a/poetry.lock
+++ b/poetry.lock
@@ -766,6 +766,14 @@ python-versions = ">=3.6"
 doc = ["reno", "sphinx", "tornado (>=4.5)"]
 
 [[package]]
+name = "tinydb"
+version = "4.5.2"
+description = "TinyDB is a tiny, document oriented database optimized for your happiness :)"
+category = "main"
+optional = false
+python-versions = ">=3.5,<4.0"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -851,7 +859,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "2fbbc9bf4dcb6d47807178770083ba76a4da94654af6b5677b096c75c656c1dc"
+content-hash = "0d3b9d458fadc79a15e13c889664071801d725a56b4843e21168d0a282a87660"
 
 [metadata.files]
 alembic = [
@@ -1176,9 +1184,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
@@ -1190,9 +1195,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1204,9 +1206,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
@@ -1219,9 +1218,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1234,9 +1230,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1522,6 +1515,10 @@ sqlalchemy = [
 tenacity = [
     {file = "tenacity-8.0.1-py3-none-any.whl", hash = "sha256:f78f4ea81b0fabc06728c11dc2a8c01277bfc5181b321a4770471902e3eb844a"},
     {file = "tenacity-8.0.1.tar.gz", hash = "sha256:43242a20e3e73291a28bcbcacfd6e000b02d3857a9a9fff56b297a27afdc932f"},
+]
+tinydb = [
+    {file = "tinydb-4.5.2-py3-none-any.whl", hash = "sha256:3c5e5c72c98db07e707be4e25f9e135a8a14b96938e4745b1b7187fec523ff58"},
+    {file = "tinydb-4.5.2.tar.gz", hash = "sha256:7d18b2d0217827c188f177cd23df60e5cd5316a717e836a8e21c8c2488262cf5"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dynaconf = "^3.1.4"
 dash = "^2.0.0"
 dash-bootstrap-components = "^1.0.0"
 waitress = "^2.0.0"
+tinydb = "^4.5.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"


### PR DESCRIPTION
`ParamStore` is a concept intended to replace QPU-DB. This PR introduces `ParamStore` as an interface (ABC) as well as a model implementation - `InProcessParamStore`.

`InProcessParamStore` holds experiment parameters in memory and persistems them to disk as JSON documents in a file (using `tindydb`) on demand. 

Functionality currently supported:
* Access parameters as composite keys (ex: `param_store["x.y.z"]`) or as object properties (ex: `param_store.x.y.z`).
* Persist to disk by calling `commit()` (with an optional `label` assigned).
* View a list of previous commits by calling `log()` (optionally filtering by `label`).
* Restore from disk by calling `checkout()` (on a `commit_id`, absolute commit number or relative steps up/down the commit history).
* Merge a dictionary or another `ParamStore` into a `ParamStore`. Two merge strategies our available to resolve conflicts: Let `OURS` take precedence or let `THEIRS` take precedence.
