### PR TITLE
Dashboard auto_plot() now plots experiment results of type Dict

### DIFF
--- a/entropylab/results/dashboard/auto_plot.py
+++ b/entropylab/results/dashboard/auto_plot.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict
 
 import numpy as np
 
@@ -8,15 +8,27 @@ from entropylab.api.plot import CirclePlotGenerator, ImShowPlotGenerator
 
 
 def auto_plot(experiment_id: int, data):
-    if isinstance(data, list):
+    if isinstance(data, dict):
+        return _auto_plot_from_dict(experiment_id, data)
+    elif isinstance(data, list):
         plot = _auto_plot_from_list(data)
     elif isinstance(data, np.ndarray):
         plot = _auto_plot_from_ndarray(data)
     else:
-        raise EntropyError("Only list and ndarrays can be auto-plotted at this time")
+        raise EntropyError(
+            "Only lists, dicts and ndarrays can be auto-plotted at this time"
+        )
     plot.experiment_id = experiment_id
     plot.id = 0
     return plot
+
+
+def _auto_plot_from_dict(experiment_id: int, data: Dict) -> PlotRecord:
+    if len(data) > 0:
+        first = list(data.values())[0]  # arbitrarily plot "first" value
+        return auto_plot(experiment_id, first)
+    else:
+        raise EntropyError("Cannot auto-plot an empty dict")
 
 
 def _auto_plot_from_list(data: List) -> PlotRecord:

--- a/entropylab/results/dashboard/tests/test_auto_plot.py
+++ b/entropylab/results/dashboard/tests/test_auto_plot.py
@@ -2,8 +2,39 @@ import numpy as np
 import pytest
 
 from entropylab.api.data_reader import PlotRecord
+from entropylab.api.errors import EntropyError
 from entropylab.api.plot import CirclePlotGenerator, ImShowPlotGenerator
 from entropylab.results.dashboard.auto_plot import auto_plot
+
+
+# Dictionaries
+
+
+def test_auto_plot_empty_dict():
+    data = dict()
+    with pytest.raises(EntropyError):
+        auto_plot(1, data)
+
+
+def test_auto_plot_dict_with_one_value():
+    data = dict(res=[10, 20, 40, 30, 50])
+    actual = auto_plot(1, data)
+    assert isinstance(actual, PlotRecord)
+    assert actual.id == 0
+    assert actual.experiment_id == 1
+    assert isinstance(actual.generator, CirclePlotGenerator)
+
+
+def test_auto_plot_dict_with_two_values():
+    data = dict(
+        res=[10, 20, 40, 30, 50],
+        foo=[-10, -20, -40, -30, -50],
+    )
+    actual = auto_plot(1, data)
+    assert isinstance(actual, PlotRecord)
+    assert actual.id == 0
+    assert actual.experiment_id == 1
+    assert isinstance(actual.generator, CirclePlotGenerator)
 
 
 # Lists


### PR DESCRIPTION
Users often return experiment results in the form of a python dictionary. This PR adds a heuristic to the `auto_plot()` function whereby in such cases the single (or first) values in the dictionary is extracted and plotted - provided it's of type `List` or `ndarray` which are the only types supported until now.