### PR TITLE
Adding entropy project dir to sys.path

### DIFF
--- a/entropylab/cli/main.py
+++ b/entropylab/cli/main.py
@@ -2,6 +2,8 @@ import argparse
 import functools
 import sys
 
+import pkg_resources
+
 from entropylab.logger import logger
 from entropylab.results.dashboard import serve_dashboard
 from entropylab.results_backend.sqlalchemy import init_db, upgrade_db
@@ -60,6 +62,13 @@ def _build_parser():
         "nargs": "?",
         "default": ".",
     }
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version="%(prog)s " + pkg_resources.get_distribution("entropylab").version,
+    )
 
     # init
     init_parser = subparsers.add_parser("init", help="initialize a new Entropy project")

--- a/entropylab/results/dashboard/__init__.py
+++ b/entropylab/results/dashboard/__init__.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import sys
 from typing import Optional
 
 from waitress import serve
@@ -28,6 +30,7 @@ def serve_dashboard(
     if debug is None:
         debug = settings.get("dashboard.debug", False)
 
+    sys.path.append(os.path.abspath(path))
     app = build_dashboard_app(path)
 
     if debug:


### PR DESCRIPTION
When users save Plots to the DB using their own custom `PlotGenerator`, the plots are later rendered by the Dashboard using the custom `PlotGenerator`. Currently if the custom `PlotGenerator` resides in the Entropy project directory, the Dashboard failed to load it. 

This PR quick fixes this issue by adding the entropy project dir to `sys.path` inside the `SqlAlchemyDB` ctor.