### PR TITLE
ParamStore merge() now correctly marks store as is_dirty when needed

### DIFF
--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -416,6 +416,23 @@ def test_merge_strategy_ours_both_sides():
     }
 
 
+def test_merge_strategy_ours_when_both_are_empty_then_store_remains_not_dirty():
+    target = InProcessParamStore()
+    theirs = InProcessParamStore()
+    target.commit()  # so is_dirty becomes False
+    target.merge(theirs, MergeStrategy.OURS)
+    assert not target.is_dirty
+
+
+def test_merge_strategy_ours_when_their_key_is_copied_then_store_is_dirty():
+    target = InProcessParamStore()
+    theirs = InProcessParamStore()
+    theirs["foo"] = "bar"
+    target.commit()  # so is_dirty becomes False
+    target.merge(theirs, MergeStrategy.OURS)
+    assert target.is_dirty
+
+
 """ merge() MergeStrategy.THEIRS """
 
 
@@ -483,6 +500,15 @@ def test_merge_strategy_theirs_both_sides():
             "c": 3,
         }
     }
+
+
+def test_merge_strategy_theirs_when_their_key_is_copied_then_store_is_dirty():
+    target = InProcessParamStore()
+    theirs = InProcessParamStore()
+    theirs["foo"] = "bar"
+    target.commit()  # so is_dirty becomes False
+    target.merge(theirs, MergeStrategy.THEIRS)
+    assert target.is_dirty
 
 
 """ list_values() """

--- a/entropylab/results/dashboard/auto_plot.py
+++ b/entropylab/results/dashboard/auto_plot.py
@@ -1,4 +1,3 @@
-import typing
 from typing import List, Dict
 
 import numpy as np

--- a/entropylab/results/dashboard/tests/test_auto_plot.py
+++ b/entropylab/results/dashboard/tests/test_auto_plot.py
@@ -144,6 +144,7 @@ def test_auto_plot_2d_ndarray():
     assert actual.experiment_id == 1
     assert isinstance(actual.generator, ImShowPlotGenerator)
 
+
 def test_auto_plot_number():
     data = 10
     actual = auto_plot(1, data)


### PR DESCRIPTION
This PR fixes issue https://github.com/entropy-lab/entropy/issues/168. The `ParamStore` `merge()` method has been modified to set `self._is_dirty` to `True` if the merge operation changed the current state of the store (i.e. `_self.params`).

Note: the internal implementation for `MergeStrategy.THEIRS` has been significantly changed to enable the fix.