### PR TITLE
Enabling the dev tools in the dashboard regardless of whether debug=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * add retry behavior for nodes - recovery from errors
+* When serving the Results Dashboard, Dash's "dev tools" feature is always enabled. 
 
 ## [0.4.1] - 2022-01-23
 ### Changed

--- a/entropylab/results/dashboard/__init__.py
+++ b/entropylab/results/dashboard/__init__.py
@@ -33,8 +33,9 @@ def serve_dashboard(
     sys.path.append(os.path.abspath(path))
     app = build_dashboard_app(path)
 
+    app.enable_dev_tools(debug=True)
+
     if debug:
-        app.enable_dev_tools(debug=debug)
         entropy_logger = logging.getLogger("entropy")
         entropy_logger.setLevel(logging.DEBUG)
         waitress_logger = logging.getLogger("waitress")


### PR DESCRIPTION
This PR resolves issue https://github.com/entropy-lab/entropy/issues/157 by always enabling Dash's "dev tools" feature in the Entropy Results Dashboard server. As requested, even if the dashboard is run with `debug=False` the feature remains enabled.