### PR TITLE
ParamStore: Save/load params to/from a temporary location

### DIFF
--- a/entropylab/api/param_store.py
+++ b/entropylab/api/param_store.py
@@ -84,6 +84,16 @@ class ParamStore(ABC):
     def list_keys(self, tag: str) -> List[str]:
         pass
 
+    """ Temporary State """
+
+    @abstractmethod
+    def save_temp(self) -> None:
+        pass
+
+    @abstractmethod
+    def load_temp(self) -> None:
+        pass
+
     @property
     @abstractmethod
     def is_dirty(self):

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -351,14 +351,14 @@ def test_list_commits_when_label_exists_then_it_is_returned(
 
 def test__generate_metadata_empty_dict():
     target = InProcessParamStore()
-    actual = target._InProcessParamStore__generate_metadata()
+    actual = target._InProcessParamStore__build_metadata()
     assert len(actual.id) == 40
 
 
 def test__generate_metadata_nonempty_dict():
     target = InProcessParamStore()
     target["foo"] = "bar"
-    actual = target._InProcessParamStore__generate_metadata()
+    actual = target._InProcessParamStore__build_metadata()
     assert len(actual.id) == 40
 
 
@@ -655,6 +655,26 @@ def test_list_keys_when_tag_exists_then_multiple_tags_are_returned():
     assert target.list_keys("tag") == ["foo", "boo"]
 
 
+""" temp """
+
+
+def test_save_temp_and_load_temp(tinydb_file_path):
+    target = InProcessParamStore(tinydb_file_path)
+    target.foo = "bar"
+    target.save_temp()
+    target.foo = "baz"
+    target.load_temp()
+    assert target.foo == "bar"
+
+
+def test_load_temp_when_save_temp_not_called_before_then_error_is_raised(
+    tinydb_file_path,
+):
+    target = InProcessParamStore(tinydb_file_path)
+    with pytest.raises(EntropyError):
+        target.load_temp()
+
+
 """ demo test """
 
 
@@ -664,7 +684,19 @@ def test_demo(tinydb_file_path):
     target["qubit1.flux_capacitor.amp"] = 5.0
     target["qubit1.flux_capacitor"] = {"wave": "manifold", "warp": 1337.0}
 
-    print(f"before commit freq: {target['qubit1.flux_capacitor.freq']}")
+    print(f"before saving to temp, freq: {target['qubit1.flux_capacitor.freq']}")
+
+    target.save_temp()
+
+    target["qubit1.flux_capacitor.freq"] = 18.0
+
+    print(f"changed after saving, freq: {target['qubit1.flux_capacitor.freq']}")
+
+    target.load_temp()
+
+    print(
+        f"loaded previous value from temp, freq: {target['qubit1.flux_capacitor.freq']}"
+    )
 
     commit_id = target.commit("warm-up")
 


### PR DESCRIPTION
This PR adds new functionality to `ParamStore` that can be useful in the earlier stages of building the experimental environment.

The method `save_temp()` saves all the params currently in memory to a temporary, persistent location (within the `ParamStore` DB file).

The method `load_temp()` loads any params saved into the temporary location into the `ParamStore` (all other values are removed from memory).