### PR TITLE
Dashboard bug fix: DataTable persistence_type set to "session"

### DIFF
--- a/entropylab/results/dashboard/table.py
+++ b/entropylab/results/dashboard/table.py
@@ -16,6 +16,7 @@ def table(records):
         ],
         data=records,
         persistence=True,
+        persistence_type="session",
         row_selectable="multi",
         cell_selectable=False,
         sort_action="native",


### PR DESCRIPTION
This PR fixes Dashboard issue https://github.com/entropy-lab/entropy/issues/158 . 

The issues was that the user's selection of experiments was persisted across both server (i.e. `entropy serve`) restarts and browser restarts. So if a user relaunched the dashboard for a new Entropy project, their selection from the previous Entropy projected would still be there, sometimes triggering errors.

This PR sets the `persistence_type` for the Experiments `DataTable` to `"session"`. This way the user's selection is reset when the browser is closed or the server is restarted.