### PR TITLE
Dashboard - Re-enabling hot reload using "hupper"

### DIFF
--- a/entropylab/results/dashboard/__init__.py
+++ b/entropylab/results/dashboard/__init__.py
@@ -3,8 +3,8 @@ import os
 import sys
 from typing import Optional
 
-from waitress import serve
-
+import hupper
+import waitress
 from entropylab.config import settings
 from entropylab.results.dashboard.dashboard import build_dashboard_app
 from entropylab.results.dashboard.theme import theme_stylesheet
@@ -41,4 +41,12 @@ def serve_dashboard(
         waitress_logger = logging.getLogger("waitress")
         waitress_logger.setLevel(logging.DEBUG)
 
-    serve(app.server, host=host, port=port)
+    # Hot reloading using hupper
+    worker_kwargs = dict(path=path, host=host, port=port, debug=debug)
+    hupper.start_reloader(
+        "entropylab.results.dashboard.serve_dashboard",
+        worker_kwargs=worker_kwargs,
+        reload_interval=0,
+    )
+
+    waitress.serve(app.server, host=host, port=port)

--- a/poetry.lock
+++ b/poetry.lock
@@ -277,7 +277,7 @@ dotenv = ["python-dotenv"]
 
 [[package]]
 name = "flask-compress"
-version = "1.10.1"
+version = "1.11"
 description = "Compress responses in your Flask app with gzip, deflate or brotli."
 category = "main"
 optional = false
@@ -343,6 +343,18 @@ python-versions = ">=3.7"
 [package.dependencies]
 cached-property = {version = "*", markers = "python_version < \"3.8\""}
 numpy = ">=1.14.5"
+
+[[package]]
+name = "hupper"
+version = "1.10.3"
+description = "Integrated process monitor for developing and reloading daemons."
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+
+[package.extras]
+docs = ["watchdog", "sphinx", "pylons-sphinx-themes"]
+testing = ["watchdog", "pytest", "pytest-cov", "mock"]
 
 [[package]]
 name = "importlib-metadata"
@@ -882,11 +894,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "waitress"
-version = "2.0.0"
+version = "2.1.0"
 description = "Waitress WSGI server"
 category = "main"
 optional = false
-python-versions = ">=3.6.0"
+python-versions = ">=3.7.0"
 
 [package.extras]
 docs = ["Sphinx (>=1.8.1)", "docutils", "pylons-sphinx-themes (>=1.0.9)"]
@@ -918,7 +930,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "649d34b19b3d5f67317bcee7426eed86242db3fab5477c657c32af99811c736e"
+content-hash = "97ee1970b7a610f3ad4fcd3a3ca33f8555ca0e3dff8f090df06ce788e5e49d45"
 
 [metadata.files]
 alembic = [
@@ -1087,8 +1099,8 @@ flask = [
     {file = "Flask-2.0.3.tar.gz", hash = "sha256:e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d"},
 ]
 flask-compress = [
-    {file = "Flask-Compress-1.10.1.tar.gz", hash = "sha256:28352387efbbe772cfb307570019f81957a13ff718d994a9125fa705efb73680"},
-    {file = "Flask_Compress-1.10.1-py3-none-any.whl", hash = "sha256:a6c2d1ff51771e9b39d7a612754f4cb4e8af20cebe16b02fd19d98d8dd6966e5"},
+    {file = "Flask-Compress-1.11.tar.gz", hash = "sha256:f569f32c446d6b25ca8e347d5003a0531811ef732678005b0036fc1c9eb1c21c"},
+    {file = "Flask_Compress-1.11-py3-none-any.whl", hash = "sha256:7ccc4102104a63e6207f39eb307f99aebbfbaf4e70992d727440cff29119a0a0"},
 ]
 fonttools = [
     {file = "fonttools-4.29.1-py3-none-any.whl", hash = "sha256:1933415e0fbdf068815cb1baaa1f159e17830215f7e8624e5731122761627557"},
@@ -1167,6 +1179,10 @@ h5py = [
     {file = "h5py-3.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:954c5c39a09b5302f69f752c3bbf165d368a65c8d200f7d5655e0fa6368a75e6"},
     {file = "h5py-3.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:9fd8a14236fdd092a20c0bdf25c3aba3777718d266fabb0fdded4fcf252d1630"},
     {file = "h5py-3.6.0.tar.gz", hash = "sha256:8752d2814a92aba4e2b2a5922d2782d0029102d99caaf3c201a566bc0b40db29"},
+]
+hupper = [
+    {file = "hupper-1.10.3-py2.py3-none-any.whl", hash = "sha256:f683850d62598c02faf3c7cdaaa727d8cbe3c5a2497a5737a8358386903b2601"},
+    {file = "hupper-1.10.3.tar.gz", hash = "sha256:cd6f51b72c7587bc9bce8a65ecd025a1e95f1b03284519bfe91284d010316cd9"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.11.2-py3-none-any.whl", hash = "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"},
@@ -1674,8 +1690,8 @@ typing-extensions = [
     {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 waitress = [
-    {file = "waitress-2.0.0-py3-none-any.whl", hash = "sha256:29af5a53e9fb4e158f525367678b50053808ca6c21ba585754c77d790008c746"},
-    {file = "waitress-2.0.0.tar.gz", hash = "sha256:69e1f242c7f80273490d3403c3976f3ac3b26e289856936d1f620ed48f321897"},
+    {file = "waitress-2.1.0-py3-none-any.whl", hash = "sha256:58bd2fa1c2c82adf6e322ae7151f4fbd5176d2769602407a61b9c92b1606c2ef"},
+    {file = "waitress-2.1.0.tar.gz", hash = "sha256:ec8a8d9b6b15f3bb2c1a82b8f3929a029c333c35fcafb08c185a9e562d8cc9c2"},
 ]
 werkzeug = [
     {file = "Werkzeug-2.0.3-py3-none-any.whl", hash = "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dash-bootstrap-components = "^1.0.0"
 waitress = "^2.0.0"
 tinydb = "^4.5.2"
 munch = "^2.5.0"
+hupper = "^1.10.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"


### PR DESCRIPTION
This PR resolves issue https://github.com/entropy-lab/entropy/issues/186. 

The issue was that the *Entropy Dashboard* was not "hot reloading" itself when code files (such as user generated Python files containing `PlotGenerator` classes). The reason for this was that we've switched from serving the *Dashboard* using Dash's built-in Flask server to serving using waitress and this made "hot reloading" [fail somehow](https://github.com/plotly/dash/issues/1955).

This PR re-introduces hot reloading using the [hupper](https://docs.pylonsproject.org/projects/hupper/en/latest/index.html) monitoring library.

Acceptance test:
1. Run the *Dashboard* on a database where you have an experiment plotted with a custom `PlotGenerator` class.
2. Make a change to the `PlotGenerator` code that should be visible in the Dashboard.
3. Observe that the *Dashboard* browser page refreshes itself within 1-5 seconds and the change is visible.