### PR TITLE
Dashboard now expands to full page length (fluid container)

### DIFF
--- a/entropylab/results/dashboard/assets/dashboard.css
+++ b/entropylab/results/dashboard/assets/dashboard.css
@@ -16,7 +16,7 @@ html,body {
 }
 
 #logo-col {
-  justify-content: center;
+  justify-content: left;
   display: flex;
 }
 
@@ -113,6 +113,7 @@ input.current-page::placeholder {
 .add-button-col-container {
   display: table-cell;
   vertical-align: middle;
+  text-align: center;
 }
 
 #add-button {
@@ -127,8 +128,7 @@ input.current-page::placeholder {
 
 .remove-button {
   width: 70px;
-  margin-top: 4px;
-  margin-bottom: 4px;
+  margin: 4px;
   border-color: #666666;
   font-size:12px;
 }

--- a/entropylab/results/dashboard/layout.py
+++ b/entropylab/results/dashboard/layout.py
@@ -9,6 +9,7 @@ from entropylab.results_backend.sqlalchemy.project import project_name, project_
 
 def layout(path: str, records: List[Dict]):
     return dbc.Container(
+        fluid=True,
         className="main",
         children=[
             dcc.Store(id="plot-figures", storage_type="session"),


### PR DESCRIPTION
This PR resolves issue https://github.com/entropy-lab/entropy/issues/189

The dashboard now expands its UI to the full length of the browser page to make better use of the display size.