### PR TITLE
Bug fix: ParamStore get() returned None when commit_id argument was None

### DIFF
--- a/entropylab/api/in_process_param_store.py
+++ b/entropylab/api/in_process_param_store.py
@@ -100,7 +100,7 @@ class InProcessParamStore(ParamStore, Munch):
     def get(self, key: str, commit_id: Optional[str] = None):
         with self.__lock:
             if commit_id is None:
-                super().__getitem__(key)
+                return super().__getitem__(key)
             else:
                 commit = self.__get_commit(commit_id)
                 return commit["params"][key]

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -118,6 +118,40 @@ def test___delitem___when_key_is_deleted_then_it_is_removed_from_tags_too():
     assert target.list_keys("tag") == ["goo"]
 
 
+""" get() """
+
+
+def test_get_when_commit_id_is_none_then_value_is_returned():
+    # arrange
+    target = InProcessParamStore()
+    target["foo"] = "bar"
+    # act
+    actual = target.get("foo")
+    # assert
+    assert actual == "bar"
+
+
+def test_get_when_commit_id_is_not_one_then_value_is_returned():
+    # arrange
+    target = InProcessParamStore()
+    target["foo"] = "bar"
+    commit_id = target.commit()
+    target["foo"] = "baz"
+    # act
+    actual = target.get("foo", commit_id)
+    # assert
+    assert actual == "bar"
+
+
+def test_get_when_commit_id_is_bad_then_entropy_error_is_raised():
+    # arrange
+    target = InProcessParamStore()
+    target["foo"] = "bar"
+    # act
+    with pytest.raises(EntropyError):
+        target.get("foo", "oops")
+
+
 """ commit() """
 
 
@@ -493,7 +527,7 @@ def test_merge_strategy_theirs_when_ours_is_leaf_theirs_is_dict_then_theirs_is_c
     assert target["foo"] == {"baz": 1}
 
 
-def test_merge_strategy_theirs_when_ours_is_dict_theirs_is_leaf_then_theirs_overwrites():
+def test_merge_strategy_theirs_when_ours_is_dict_theirs_is_leaf_then_their_overwrites():
     target = InProcessParamStore()
     target["foo"] = {"bar": 1}
     theirs = InProcessParamStore()
@@ -706,7 +740,8 @@ def test_demo(tinydb_file_path):
 
     print(f"second commit freq: {target['qubit1.flux_capacitor.freq']}")
     print(
-        f"first commit freq from history: {target.get('qubit1.flux_capacitor.freq', commit_id)}"
+        f"first commit freq from history: "
+        f"{target.get('qubit1.flux_capacitor.freq', commit_id)}"
     )
 
     target.commit("warm-up")


### PR DESCRIPTION
This PR fixes a bug that I've found in `InProcessParamStore`'s `get()` method. When `get()` was called without its second, optional argument (`commit_id`) it would not return a value. The word `return` was missing [here](https://github.com/entropy-lab/entropy/blob/3b7644fa3dc213adf07aa3774d458a7d76132da2/entropylab/api/in_process_param_store.py#L103).
