### PR TITLE
Fixing logging issue #204: Stop Alembic from disabling non-Alembic loggers

### DIFF
--- a/entropylab/results_backend/sqlalchemy/alembic/env.py
+++ b/entropylab/results_backend/sqlalchemy/alembic/env.py
@@ -1,9 +1,8 @@
 from logging.config import fileConfig
 
+from alembic import context
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
-
-from alembic import context
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -13,7 +12,7 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/entropylab/tests/test_issue_204.py
+++ b/entropylab/tests/test_issue_204.py
@@ -1,0 +1,47 @@
+import os
+from datetime import datetime
+
+import pytest
+
+from entropylab import ExperimentResources, SqlAlchemyDB, PyNode, Graph
+
+
+@pytest.mark.skipif(
+    datetime.utcnow() > datetime(2022, 6, 25),
+    reason="Please remove after two months have passed since the fix was merged",
+)
+def test_issue_204(initialized_project_dir_path, capsys):
+    # arrange
+
+    # remove DB files because when they are present, issue does not occur
+    db_files = [".entropy/params.db", ".entropy/entropy.db", ".entropy/entropy.hdf5"]
+    for file in db_files:
+        full_path = os.path.join(initialized_project_dir_path, file)
+        if os.path.exists(full_path):
+            os.remove(full_path)
+
+    # experiment to run
+    experiment_resources = ExperimentResources(
+        SqlAlchemyDB(initialized_project_dir_path)
+    )
+
+    def root_node():
+        print("root node")
+        # error that should be logged to stderr:
+        print(a)
+        return {}
+
+    node0 = PyNode(label="root_node", program=root_node)
+    experiment = Graph(resources=experiment_resources, graph={node0}, story="run_a")
+
+    # act
+
+    try:
+        experiment.run()
+    except RuntimeError:
+        pass
+
+    # assert
+
+    captured = capsys.readouterr()
+    assert "message: name 'a' is not defined" in captured.err


### PR DESCRIPTION
This PR resolves issue https://github.com/entropy-lab/entropy/issues/204.

The root cause of the issue is that when `fileConfig(config.config_file_name)` is called in Alembic's `env.py` it has its `disable_existing_loggers` argument set to `True` by default  and this disables the Entropy logger.

This issue sets the `disable_existing_loggers` to `False` and verifies correct behavior via a unit test.