### PR TITLE
New ParamStore methods: rename_key() and list_tags_for_key()

### DIFF
--- a/entropylab/api/in_process_param_store.py
+++ b/entropylab/api/in_process_param_store.py
@@ -110,6 +110,25 @@ class InProcessParamStore(ParamStore, Munch):
             if key in self.__tags[tag]:
                 self.__tags[tag].remove(key)
 
+    def rename_key(self, key: str, new_key: str):
+        with self.__lock:
+            if new_key in self.keys():
+                raise KeyError(
+                    f"Cannot rename key '{key}' to key '{new_key}' because it already exists"
+                )
+            self.__rename_key_in_tags(key, new_key)
+            value = self.__getitem__(key)
+            self.__setitem__(new_key, value)
+            self.__delitem__(key)
+
+    def __rename_key_in_tags(self, key, new_key):
+        for item in self.__tags.items():
+            tag = item[0]
+            keys = item[1]
+            if key in keys:
+                self.__tags[tag].remove(key)
+                self.__tags[tag].append(new_key)
+
     """ Commits """
 
     def commit(self, label: Optional[str] = None) -> str:

--- a/entropylab/api/in_process_param_store.py
+++ b/entropylab/api/in_process_param_store.py
@@ -282,12 +282,19 @@ class InProcessParamStore(ParamStore, Munch):
             self.__tags[tag].remove(key)
             self.__is_dirty = True
 
-    def list_keys(self, tag: str) -> List[str]:
+    def list_keys_for_tag(self, tag: str) -> List[str]:
         with self.__lock:
             if tag not in self.__tags:
                 return []
             else:
                 return self.__tags[tag]
+
+    def list_tags_for_key(self, key: str):
+        tags_for_key = []
+        for item in self.__tags.items():
+            if key in item[1]:
+                tags_for_key.append(item[0])
+        return tags_for_key
 
     """ Temporary State """
 

--- a/entropylab/api/param_store.py
+++ b/entropylab/api/param_store.py
@@ -30,6 +30,10 @@ class ParamStore(ABC):
         pass
 
     @abstractmethod
+    def rename_key(self, key: str, new_key: str):
+        pass
+
+    @abstractmethod
     def commit(self, label):
         pass
 

--- a/entropylab/api/param_store.py
+++ b/entropylab/api/param_store.py
@@ -81,7 +81,11 @@ class ParamStore(ABC):
         pass
 
     @abstractmethod
-    def list_keys(self, tag: str) -> List[str]:
+    def list_keys_for_tag(self, tag: str) -> List[str]:
+        pass
+
+    @abstractmethod
+    def list_tags_for_key(self, key: str):
         pass
 
     """ Temporary State """

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -152,6 +152,47 @@ def test_get_when_commit_id_is_bad_then_entropy_error_is_raised():
         target.get("foo", "oops")
 
 
+def test_rename_key_when_key_exists_then_it_is_renamed():
+    # arrange
+    target = InProcessParamStore()
+    target["foo"] = dict(bar="baz")
+    # act
+    target.rename_key("foo", "new")
+    # assert
+    assert target["new"]["bar"] == "baz"
+
+
+def test_rename_key_when_key_does_not_exist_then_an_error_is_raised():
+    # arrange
+    target = InProcessParamStore()
+    # act & assert
+    with pytest.raises(KeyError):
+        target.rename_key("foo", "new")
+
+
+def test_rename_key_when_new_key_exists_then_an_error_is_raised():
+    # arrange
+    target = InProcessParamStore()
+    target["foo"] = dict(bar="baz")
+    target["new"] = 42
+
+    # act & assert
+    with pytest.raises(KeyError):
+        target.rename_key("foo", "new")
+
+
+def test_rename_key_when_key_has_a_tag_then_tag_remains():
+    # arrange
+    target = InProcessParamStore()
+    target["foo"] = dict(bar="baz")
+    target.add_tag("tag", "foo")
+    # act
+    target.rename_key("foo", "new")
+    # assert
+    assert "tag" in target.list_tags_for_key("new")
+    assert "tag" not in target.list_tags_for_key("foo")
+
+
 """ commit() """
 
 
@@ -689,7 +730,7 @@ def test_list_keys_for_tag_when_tag_exists_then_multiple_tags_are_returned():
     assert target.list_keys_for_tag("tag") == ["foo", "boo"]
 
 
-def test_list_tags_for_key_when_has_tags_then_they_are_returned():
+def test_list_tags_for_key_when_key_has_tags_then_they_are_returned():
     target = InProcessParamStore()
     target["foo"] = "bar"
     target.add_tag("tag1", "foo")

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -115,7 +115,7 @@ def test___delitem___when_key_is_deleted_then_it_is_removed_from_tags_too():
     target.add_tag("tag", "goo")
     # act
     del target["foo"]
-    assert target.list_keys("tag") == ["goo"]
+    assert target.list_keys_for_tag("tag") == ["goo"]
 
 
 """ get() """
@@ -275,7 +275,7 @@ def test_checkout_when_tag_existed_in_commit_then_it_is_added_to_store(
     commit_id = target.commit()
     target.remove_tag("tag", "foo")
     target.checkout(commit_id)
-    assert target.list_keys("tag") == ["foo"]
+    assert target.list_keys_for_tag("tag") == ["foo"]
 
 
 def test_checkout_when_tag_did_not_exist_in_commit_then_it_is_removed_from_store(
@@ -287,7 +287,7 @@ def test_checkout_when_tag_did_not_exist_in_commit_then_it_is_removed_from_store
     commit_id = target.commit()
     target.add_tag("tag", "foo")
     target.checkout(commit_id)
-    assert target.list_keys("tag") == []
+    assert target.list_keys_for_tag("tag") == []
 
 
 @pytest.mark.parametrize(
@@ -656,7 +656,7 @@ def test_add_tag_when_key_exists_then_tag_is_added():
     target = InProcessParamStore()
     target["foo"] = "bar"
     target.add_tag("tag", "foo")
-    assert "foo" in target.list_keys("tag")
+    assert "foo" in target.list_keys_for_tag("tag")
     assert target.is_dirty
 
 
@@ -675,18 +675,37 @@ def test_remove_tag_when_tag_doesnt_exist_then_nothing_happens():
     assert not target.is_dirty
 
 
-def test_list_keys_when_tag_doesnt_exist_then_empty_list_is_returned():
+def test_list_keys_for_tag_when_tag_doesnt_exist_then_empty_list_is_returned():
     target = InProcessParamStore()
-    assert target.list_keys("tag") == []
+    assert target.list_keys_for_tag("tag") == []
 
 
-def test_list_keys_when_tag_exists_then_multiple_tags_are_returned():
+def test_list_keys_for_tag_when_tag_exists_then_multiple_tags_are_returned():
     target = InProcessParamStore()
     target["foo"] = "bar"
     target["boo"] = "baz"
     target.add_tag("tag", "foo")
     target.add_tag("tag", "boo")
-    assert target.list_keys("tag") == ["foo", "boo"]
+    assert target.list_keys_for_tag("tag") == ["foo", "boo"]
+
+
+def test_list_tags_for_key_when_has_tags_then_they_are_returned():
+    target = InProcessParamStore()
+    target["foo"] = "bar"
+    target.add_tag("tag1", "foo")
+    target.add_tag("tag2", "foo")
+    assert target.list_tags_for_key("foo") == ["tag1", "tag2"]
+
+
+def test_list_tags_for_key_when_key_has_no_tags_then_empty_list_is_returned():
+    target = InProcessParamStore()
+    target["foo"] = "bar"
+    assert target.list_tags_for_key("foo") == []
+
+
+def test_list_tags_for_key_when_key_does_not_exist_then_empty_list_is_returned():
+    target = InProcessParamStore()
+    assert target.list_tags_for_key("foo") == []
 
 
 """ temp """


### PR DESCRIPTION
This PR introduces two new methods for the ParamStore ABC and implementation:

1. `rename_key(key, new_key)` renames an existing key to a new key.
2. `list_tags_for_key(key)` returns a list of all tags assigned to the key.

Additionally the method `list_keys()` has been renamed `list_keys_for_tag()` to improve readability.