### PR TITLE
ParamStore now contains Params

### DIFF
--- a/entropylab/api/in_process_param_store.py
+++ b/entropylab/api/in_process_param_store.py
@@ -123,6 +123,9 @@ class InProcessParamStore(ParamStore):
     def __contains__(self, key):
         return self.__params.__contains__(key)
 
+    def keys(self):
+        return self.__params.keys()
+
     def to_dict(self) -> Dict:
         with self.__lock:
             return copy.deepcopy(self.__params)

--- a/entropylab/api/in_process_param_store.py
+++ b/entropylab/api/in_process_param_store.py
@@ -138,6 +138,10 @@ class InProcessParamStore(ParamStore):
         with self.__lock:
             return self.__params.__contains__(key)
 
+    def __repr__(self):
+        with self.__lock:
+            return f"<InProcessParamStore({self.to_dict().__repr__()})>"
+
     def keys(self):
         with self.__lock:
             return self.__params.keys()

--- a/entropylab/api/param_store.py
+++ b/entropylab/api/param_store.py
@@ -13,7 +13,12 @@ class MergeStrategy(Enum):
     THEIRS = 2
 
 
+# TODO: Derive from MutableMapping (-> rename get() to get_value())
 class ParamStore(ABC):
+    @abstractmethod
+    def keys(self):
+        pass
+
     @abstractmethod
     def to_dict(self):
         pass

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -118,6 +118,13 @@ def test___delitem___when_key_is_deleted_then_it_is_removed_from_tags_too():
     assert target.list_keys_for_tag("tag") == ["goo"]
 
 
+def test___repr__():
+    target = InProcessParamStore()
+    target["foo"] = "bar"
+    actual = target.__repr__()
+    assert actual == "<InProcessParamStore({'foo': 'bar'})>"
+
+
 """ get() """
 
 

--- a/entropylab/api/tests/test_param_store.py
+++ b/entropylab/api/tests/test_param_store.py
@@ -131,7 +131,7 @@ def test_get_when_commit_id_is_none_then_value_is_returned():
     assert actual == "bar"
 
 
-def test_get_when_commit_id_is_not_one_then_value_is_returned():
+def test_get_when_commit_id_is_not_none_then_value_is_returned():
     # arrange
     target = InProcessParamStore()
     target["foo"] = "bar"


### PR DESCRIPTION
This PR introduces a change to the internal implementation of the `InProcessParamStore`. Values inside the store are now wrapped in a container class called `Param`. `InProcessParamStore` wraps values when they are entered and unwraps them when they are recalled. 

The change is in preparation of augmenting `ParamStore` with "per-key metadata" which will be stored inside the `Param` wrapper instances.

A side effect of this PR is that `InProcessParamStore no longer inherits from `Munch` thereby resolving issue https://github.com/entropy-lab/entropy/issues/208 .