### PR TITLE
Migrating ParamStore JSON file to v0.2 (where values are wrapped by Param instances)

### DIFF
--- a/entropylab/dashboard/app.py
+++ b/entropylab/dashboard/app.py
@@ -10,6 +10,7 @@ from entropylab.dashboard.theme import (
     theme_stylesheet,
 )
 from entropylab.pipeline.results_backend.sqlalchemy.project import (
+from entropylab.logger import logger
     project_name,
     project_path,
     param_store_path,
@@ -38,7 +39,12 @@ def build_dashboard_app(proj_path):
     """ Initializing data sources """
 
     dashboard_data_reader = SqlalchemyDashboardDataReader(SqlAlchemyDB(proj_path))
-    param_store = InProcessParamStore(param_store_path(proj_path))
+    # noinspection PyBroadException
+    try:
+        param_store = InProcessParamStore(param_store_path(proj_path))
+    except BaseException as e:
+        logger.exception(f"Exception when loading ParamStore from '{proj_path}'")
+        raise e
 
     """ Building page layouts """
 

--- a/entropylab/pipeline/api/in_process_param_store.py
+++ b/entropylab/pipeline/api/in_process_param_store.py
@@ -60,6 +60,11 @@ class InProcessParamStore(ParamStore):
             self.__is_in_memory_mode = False
             if isinstance(path, Path):
                 path = str(path)
+            if not os.path.isfile(path):
+                logger.debug(
+                    f"ParamStore JSON file at '{path}' does not "
+                    f"exist. It will be created."
+                )
             self.__db = TinyDB(path, storage=JSONPickleStorage)
         if theirs is not None:
             self.merge(theirs, merge_strategy)


### PR DESCRIPTION
This PR supersedes PR https://github.com/entropy-lab/entropy/pull/233

A previous PR (https://github.com/entropy-lab/entropy/pull/227) augmented the `InProcessParamStore` implementation to wrap values in instances of the `Param` class. This was done to enable adding bits of metadata to `ParamStore` values in the future. This change, however, is a breaking change in that `ParamStore` JSON files stored using the previous method can no longer be read by the new code.

This PR gives Entropy users a tool to automatically upgrade older `ParamStore` JSON files to the new format supporting `Param` instances. When users instantiate a new `SqlAlchemy` instance on an existing project they are stopped with a message asking them to upgrade.

Users can then upgrade their `ParamStore` JSON files by running the `entropy upgrade <project dir path>` CLI command. The command assumes the JSON file is present at its default location in `<project dir path>/.entropy/params.json`.