### PR TITLE
Debug log for Entropy Dashboard

### DIFF
--- a/entropylab/dashboard/__init__.py
+++ b/entropylab/dashboard/__init__.py
@@ -1,13 +1,17 @@
 import logging
 import os
 import sys
+from logging.handlers import RotatingFileHandler
 from typing import Optional
 
 import hupper
 import waitress
+from hupper.interfaces import ILogger
 
 from entropylab.config import settings
 from entropylab.dashboard.app import build_dashboard_app
+from entropylab.logger import logger
+from entropylab.pipeline.results_backend.sqlalchemy.project import dashboard_log_path
 
 
 def serve_dashboard(
@@ -23,6 +27,20 @@ def serve_dashboard(
     :param port: The port name from which to server the app. Defaults to 8050.
     :param debug: Start the dashboard in debug mode. Defaults to False.
     """
+
+    # debug mode
+    if debug:
+        file_handler = _create_file_handler(dashboard_log_path(path))
+
+        _set_to_debug(logger, file_handler)
+        _set_to_debug(logging.getLogger("waitress"), file_handler)
+        _set_to_debug(logging.getLogger("hupper"), file_handler)
+
+        hupper_logger = HupperLogger(logging.DEBUG)
+    else:
+        hupper_logger = None
+
+    # defaults for args
     if host is None:
         host = settings.get("dashboard.host", "127.0.0.1")
     if port is None:
@@ -30,24 +48,55 @@ def serve_dashboard(
     if debug is None:
         debug = settings.get("dashboard.debug", False)
 
+    # voodoo!
     sys.path.append(os.path.abspath(path))
 
+    # building our Dash app
+    # noinspection PyShadowingNames
     app = build_dashboard_app(path)
-
     app.enable_dev_tools(debug=True)
 
-    if debug:
-        entropy_logger = logging.getLogger("entropy")
-        entropy_logger.setLevel(logging.DEBUG)
-        waitress_logger = logging.getLogger("waitress")
-        waitress_logger.setLevel(logging.DEBUG)
-
-    # Hot reloading using hupper
+    # hot reloading using hupper
     worker_kwargs = dict(path=path, host=host, port=port, debug=debug)
     hupper.start_reloader(
         "entropylab.dashboard.serve_dashboard",
         worker_kwargs=worker_kwargs,
         reload_interval=0,
+        logger=hupper_logger,
     )
 
+    # finally
     waitress.serve(app.server, host=host, port=port)
+
+
+def _create_file_handler(log_path):
+    file_handler = RotatingFileHandler(
+        log_path, maxBytes=10 * 1024 * 1024, backupCount=7
+    )
+    file_handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    file_handler.setFormatter(formatter)
+    return file_handler
+
+
+# noinspection PyShadowingNames
+def _set_to_debug(logger: logging.Logger, file_handler):
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(file_handler)
+
+
+class HupperLogger(ILogger):
+    def __init__(self, level):
+        self.logger = logging.getLogger("hupper")
+        logger.setLevel(level)
+
+    def error(self, msg):
+        self.logger.error(msg)
+
+    def info(self, msg):
+        self.logger.info(msg)
+
+    def debug(self, msg):
+        self.logger.debug(msg)

--- a/entropylab/dashboard/app.py
+++ b/entropylab/dashboard/app.py
@@ -1,7 +1,6 @@
 from dash import Dash, html, dcc, callback, Output, Input
 
 from entropylab import SqlAlchemyDB
-from entropylab.pipeline.api.in_process_param_store import InProcessParamStore
 from entropylab.dashboard.pages import results, params
 from entropylab.dashboard.pages.results.dashboard_data import (
     SqlalchemyDashboardDataReader,
@@ -9,6 +8,8 @@ from entropylab.dashboard.pages.results.dashboard_data import (
 from entropylab.dashboard.theme import (
     theme_stylesheet,
 )
+from entropylab.logger import logger
+from entropylab.pipeline.api.in_process_param_store import InProcessParamStore
 from entropylab.pipeline.results_backend.sqlalchemy.project import (
     project_name,
     project_path,
@@ -38,7 +39,15 @@ def build_dashboard_app(proj_path):
     """ Initializing data sources """
 
     dashboard_data_reader = SqlalchemyDashboardDataReader(SqlAlchemyDB(proj_path))
-    param_store = InProcessParamStore(param_store_file_path(proj_path))
+    # noinspection PyBroadException
+    try:
+        param_store_file = param_store_file_path(proj_path)
+        param_store = InProcessParamStore(param_store_file)
+    except BaseException as e:
+        logger.exception(
+            f"Exception when loading ParamStore file at '{param_store_file}'"
+        )
+        raise e
 
     """ Building page layouts """
 

--- a/entropylab/pipeline/api/in_process_param_store.py
+++ b/entropylab/pipeline/api/in_process_param_store.py
@@ -17,9 +17,9 @@ from tinydb import TinyDB, Query
 from tinydb.storages import MemoryStorage, Storage
 from tinydb.table import Document
 
+from entropylab.logger import logger
 from entropylab.pipeline.api.errors import EntropyError
 from entropylab.pipeline.api.param_store import ParamStore, MergeStrategy
-from entropylab.logger import logger
 
 INFO_DOC_ID = 1
 INFO_TABLE = "info"
@@ -115,8 +115,8 @@ class InProcessParamStore(ParamStore):
                 path = str(path)
             if not os.path.isfile(path):
                 logger.debug(
-                    f"ParamStore JSON file at '{path}' does not "
-                    f"exist. It will be created."
+                    f"Could not find a ParamStore JSON file at '{path}'. "
+                    f"A new, empty file will be created."
                 )
             self.__db = TinyDB(path, storage=JSONPickleStorage)
         if theirs is not None:

--- a/entropylab/pipeline/api/in_process_param_store.py
+++ b/entropylab/pipeline/api/in_process_param_store.py
@@ -113,6 +113,11 @@ class InProcessParamStore(ParamStore):
             self.__is_in_memory_mode = False
             if isinstance(path, Path):
                 path = str(path)
+            if not os.path.isfile(path):
+                logger.debug(
+                    f"ParamStore JSON file at '{path}' does not "
+                    f"exist. It will be created."
+                )
             self.__db = TinyDB(path, storage=JSONPickleStorage)
         if theirs is not None:
             self.merge(theirs, merge_strategy)

--- a/entropylab/pipeline/results_backend/sqlalchemy/project.py
+++ b/entropylab/pipeline/results_backend/sqlalchemy/project.py
@@ -40,3 +40,7 @@ def hdf5_dir_path(prj_path: str) -> Path:
 
 def param_store_file_path(prj_path: str) -> Path:
     return project_path(prj_path).joinpath(".entropy", "params.json")
+
+
+def dashboard_log_path(prj_path: str) -> Path:
+    return project_path(prj_path).joinpath(".entropy", "dashboard.log")


### PR DESCRIPTION
New debugging feature for the Entropy Dashboard. Add the `--debug` command line argument to the `entropy serve` command and a rotating log file will record all log messages from level `DEBUG` and up. The file can be found in the project `.entropy` folder under the name `dashboard.log`.