### PR TITLE
Update graph.py: fix bug in `.ancestors()` method

### DIFF
--- a/entropylab/pipeline/api/graph.py
+++ b/entropylab/pipeline/api/graph.py
@@ -169,8 +169,7 @@ class Node(ABC):
         :return: a set of node's ancestors, including current node
         """
         parents: Set[Node] = set(
-            [var.node for var in self._input_vars.values()] +
-            list(self._must_run_after)
+            [var.node for var in self._input_vars.values()] + list(self._must_run_after)
         )
         ancestors = parents.copy()
         ancestors.add(self)

--- a/entropylab/pipeline/api/graph.py
+++ b/entropylab/pipeline/api/graph.py
@@ -168,7 +168,10 @@ class Node(ABC):
         """
         :return: a set of node's ancestors, including current node
         """
-        parents: Set[Node] = set([var.node for var in self._input_vars.values()])
+        parents: Set[Node] = set(
+            [var.node for var in self._input_vars.values()] +
+            list(self._must_run_after)
+        )
         ancestors = parents.copy()
         ancestors.add(self)
         for anc in parents:


### PR DESCRIPTION
take into account node dependencies specified by kwarg `must_run_after` (ones without passing variables between nodes) when finding ancestors

# replace this template text
>  Fixing a bug reported in Issue #248 

Remember to:
* Update the CHANGELOG.md
* Added tests for the feature or fix