### PR TITLE
Dashboard: New column-based layout for the "experiment results" page

### DIFF
--- a/entropylab/dashboard/assets/dashboard.css
+++ b/entropylab/dashboard/assets/dashboard.css
@@ -123,32 +123,25 @@ input.current-page::placeholder {
   height: 450px;
 }
 
-.add-button-col {
-  display: table;
-  overflow: hidden;
-}
-
-.add-button-col-container {
-  display: table-cell;
-  vertical-align: middle;
-  text-align: center;
+.add-button-container {
+  margin-top:20px;
+  display: flex
+  align-items: center;
+  justify-content: center;
 }
 
 #add-button {
-  /* margin-top: 45px; */
-  font-size:12px;
+  width: 300px;
 }
 
 #remove-title {
-  margin-top:40px;
-  font-size:12px;
+  margin-top:20px;
 }
 
 .remove-button {
   width: 70px;
   margin: 4px;
   border-color: #666666;
-  font-size:12px;
 }
 
 .remove-button:hover {
@@ -175,9 +168,16 @@ input.current-page::placeholder {
   width:154px;
 }
 
+#aggregate-clipboard {
+  position: absolute;
+  top: 5px;
+  left: 20px;
+}
+
 #copy-data-button {
   position: absolute;
-  top: 3px;
-  left: 240px;
-  font-size:12px;
+  top: 20px;
+  right: 0px;
+  width: 220px;
+  text-align: right;
 }

--- a/entropylab/dashboard/assets/dashboard.css
+++ b/entropylab/dashboard/assets/dashboard.css
@@ -181,3 +181,18 @@ input.current-page::placeholder {
   width: 220px;
   text-align: right;
 }
+
+
+#footer-links div {
+  text-align: center !important;
+}
+
+#footer-links div a {
+  color: white;
+  text-decoration: none;
+}
+
+#footer-links div  a:hover {
+  color: white;
+  text-decoration: underline;
+}

--- a/entropylab/dashboard/assets/dashboard.css
+++ b/entropylab/dashboard/assets/dashboard.css
@@ -13,6 +13,11 @@ html,body {
 /* Top bar nav items */
 .navbar .nav-item .nav-link {
   color: var(--bg-primary) !important;
+  font-size: 24px;
+}
+
+.navbar .nav-item .nav-link.active {
+  font-weight: 900 !important;
 }
 
 #logo-col {
@@ -23,11 +28,18 @@ html,body {
 #project-name {
   font-family: monospace !important;
   font-weight: 900 !important;
-  font-size: 24px;
+  font-size: 28px;
 }
 
-#experiments-title {
+
+#experiments-title,
+#plots-title {
   margin-top:20px;
+}
+
+#experiments-table {
+  height: 1100px;
+  overflow-y: auto;
 }
 
 /* "success" column filter */
@@ -83,10 +95,6 @@ html,body {
   background-color: var(--bs-secondary);
 }
 
-#no-paging-spacer {
-  height:40px
-}
-
 input.current-page::placeholder {
   color: var(--bs-body-color) !important;
 }
@@ -138,10 +146,17 @@ input.current-page::placeholder {
   margin-top:20px;
 }
 
+.remove-button-label {
+}
+
 .remove-button {
-  width: 70px;
+  width: 90px;
+  height: 60px;
   margin: 4px;
   border-color: #666666;
+  display: flex
+  align-items: center;
+  justify-content: center;
 }
 
 .remove-button:hover {

--- a/entropylab/dashboard/assets/dashboard.css
+++ b/entropylab/dashboard/assets/dashboard.css
@@ -135,7 +135,7 @@ input.current-page::placeholder {
 }
 
 #add-button {
-  margin-top: 45px;
+  /* margin-top: 45px; */
   font-size:12px;
 }
 

--- a/entropylab/dashboard/pages/components/footer.py
+++ b/entropylab/dashboard/pages/components/footer.py
@@ -14,7 +14,7 @@ def footer():
             dbc.Col(
                 dbc.Row(
                     children=[
-                        dbc.Col(f"Entropylab v{version}", width=3),
+                        dbc.Col(f"Entropylab v{version}", width=4),
                         dbc.Col(" · ", width=1),
                         dbc.Col(
                             dbc.Row(
@@ -48,11 +48,11 @@ def footer():
                                 ],
                                 id="footer-links",
                             ),
-                            width=8,
+                            width=7,
                         ),
                     ]
                 ),
-                width=dict(size=6, offset=3),
+                width=dict(size=4, offset=4),
             ),
         ],
         style=dict(marginTop="40px", marginBottom="40px"),

--- a/entropylab/dashboard/pages/components/footer.py
+++ b/entropylab/dashboard/pages/components/footer.py
@@ -1,0 +1,59 @@
+import dash_bootstrap_components as dbc
+import pkg_resources
+from dash import html
+
+
+def footer():
+    version = pkg_resources.get_distribution("entropylab").version
+
+    href_home = "https://github.com/entropy-lab/entropy/"
+    href_documentation = "https://entropylab-docs-open.netlify.app/"
+    href_feedback = "https://github.com/entropy-lab/entropy/issues/"
+    return dbc.Row(
+        children=[
+            dbc.Col(
+                dbc.Row(
+                    children=[
+                        dbc.Col(f"Entropylab v{version}", width=3),
+                        dbc.Col(" · ", width=1),
+                        dbc.Col(
+                            dbc.Row(
+                                children=[
+                                    dbc.Col(
+                                        html.A(
+                                            "Home",
+                                            href=href_home,
+                                            target="_blank",
+                                        ),
+                                        width=3,
+                                    ),
+                                    dbc.Col("|", width=1),
+                                    dbc.Col(
+                                        html.A(
+                                            "Documentation",
+                                            href=href_documentation,
+                                            target="_blank",
+                                        ),
+                                        width=4,
+                                    ),
+                                    dbc.Col("|", width=1),
+                                    dbc.Col(
+                                        html.A(
+                                            "Feedback",
+                                            href=href_feedback,
+                                            target="_blank",
+                                        ),
+                                        width=3,
+                                    ),
+                                ],
+                                id="footer-links",
+                            ),
+                            width=8,
+                        ),
+                    ]
+                ),
+                width=dict(size=6, offset=3),
+            ),
+        ],
+        style=dict(marginTop="40px", marginBottom="40px"),
+    )

--- a/entropylab/dashboard/pages/components/top_bar.py
+++ b/entropylab/dashboard/pages/components/top_bar.py
@@ -49,7 +49,9 @@ def top_bar(path: str):
                                     )
                                 )
                             ),
-                            dbc.Col(dbc.NavItem(dbc.NavLink("Params", href="/params"))),
+                            dbc.Col(
+                                dbc.NavItem(dbc.NavLink("🧮 Params", href="/params"))
+                            ),
                         ]
                     ),
                     width="6",

--- a/entropylab/dashboard/pages/components/top_bar.py
+++ b/entropylab/dashboard/pages/components/top_bar.py
@@ -1,0 +1,60 @@
+import dash_bootstrap_components as dbc
+from dash import html
+
+from entropylab.pipeline.results_backend.sqlalchemy.project import (
+    project_name,
+    project_path,
+)
+
+
+def top_bar(path: str):
+    return dbc.Row(
+        dbc.Navbar(
+            [
+                dbc.Col(
+                    dbc.NavbarBrand(
+                        html.Img(
+                            src="/assets/images/entropy_logo_dark.svg",
+                            width=150,
+                            id="entropy-logo",
+                        ),
+                        href="#",
+                    ),
+                    width="2",
+                    id="logo-col",
+                ),
+                dbc.Col(
+                    [
+                        html.Div(
+                            f"Project: {project_name(path)}",
+                            id="project-name",
+                        ),
+                        html.Div(
+                            f"{project_path(path)}",
+                            id="project-name",
+                            style={"fontSize": "11px"},
+                        ),
+                    ],
+                    width="4",
+                ),
+                dbc.Col(
+                    dbc.Row(
+                        [
+                            dbc.Col(
+                                dbc.NavItem(
+                                    dbc.NavLink(
+                                        "🔬 Experiment Results",
+                                        href="/",
+                                        active=True,
+                                    )
+                                )
+                            ),
+                            dbc.Col(dbc.NavItem(dbc.NavLink("Params", href="/params"))),
+                        ]
+                    ),
+                    width="6",
+                ),
+            ],
+            color="primary",
+        ),
+    )

--- a/entropylab/dashboard/pages/params/layout.py
+++ b/entropylab/dashboard/pages/params/layout.py
@@ -30,14 +30,6 @@ def build_layout(path: str, param_store: ParamStore):
             ),
             top_bar(path),
             dbc.Row(
-                dbc.Col(
-                    [
-                        html.H5("Params", id="params-title"),
-                    ],
-                    width="12",
-                )
-            ),
-            dbc.Row(
                 children=[
                     dbc.Col(
                         [

--- a/entropylab/dashboard/pages/params/layout.py
+++ b/entropylab/dashboard/pages/params/layout.py
@@ -1,7 +1,8 @@
 import dash_bootstrap_components as dbc
 from dash import html, dcc, dash_table
 
-from entropylab.pipeline.api.param_store import ParamStore
+from entropylab.dashboard.pages.components.footer import footer
+from entropylab.dashboard.pages.components.top_bar import top_bar
 from entropylab.dashboard.pages.params.utils import (
     param_store_to_commits_df,
     param_store_to_df,
@@ -13,10 +14,7 @@ from entropylab.dashboard.theme import (
     table_style_cell,
     table_active_cell_conditional,
 )
-from entropylab.pipeline.results_backend.sqlalchemy.project import (
-    project_name,
-    project_path,
-)
+from entropylab.pipeline.api.param_store import ParamStore
 
 REFRESH_INTERVAL_IN_MILLIS = 3000
 
@@ -30,59 +28,7 @@ def build_layout(path: str, param_store: ParamStore):
             dcc.Interval(
                 id="interval", interval=REFRESH_INTERVAL_IN_MILLIS, n_intervals=0
             ),
-            dbc.Row(
-                dbc.Navbar(
-                    [
-                        dbc.Col(
-                            dbc.NavbarBrand(
-                                html.Img(
-                                    src="/assets/images/entropy_logo_dark.svg",
-                                    width=150,
-                                    id="entropy-logo",
-                                ),
-                                href="#",
-                            ),
-                            width="2",
-                            id="logo-col",
-                        ),
-                        dbc.Col(
-                            [
-                                html.Div(
-                                    f"Project: {project_name(path)}", id="project-name"
-                                ),
-                                html.Div(
-                                    f"{project_path(path)}",
-                                    id="project-name",
-                                    style={"fontSize": "11px"},
-                                ),
-                            ],
-                            width="4",
-                        ),
-                        dbc.Col(
-                            dbc.Row(
-                                [
-                                    dbc.Col(
-                                        dbc.NavItem(
-                                            dbc.NavLink(
-                                                "Experiment Results",
-                                                href="/",
-                                                active=True,
-                                            )
-                                        )
-                                    ),
-                                    dbc.Col(
-                                        dbc.NavItem(
-                                            dbc.NavLink("Params", href="/params")
-                                        )
-                                    ),
-                                ]
-                            ),
-                            width="6",
-                        ),
-                    ],
-                    color="primary",
-                ),
-            ),
+            top_bar(path),
             dbc.Row(
                 dbc.Col(
                     [
@@ -240,5 +186,6 @@ def build_layout(path: str, param_store: ParamStore):
                     ),
                 ],
             ),
+            footer(),
         ],
     )

--- a/entropylab/dashboard/pages/results/callbacks.py
+++ b/entropylab/dashboard/pages/results/callbacks.py
@@ -10,13 +10,13 @@ from dash.dependencies import Input, Output, State, ALL
 from plotly import graph_objects as go
 from plotly.subplots import make_subplots
 
-from entropylab.pipeline.api.data_reader import PlotRecord, FigureRecord
-from entropylab.pipeline.api.errors import EntropyError
 from entropylab.dashboard.theme import (
     colors,
     dark_plot_layout,
 )
 from entropylab.logger import logger
+from entropylab.pipeline.api.data_reader import PlotRecord, FigureRecord
+from entropylab.pipeline.api.errors import EntropyError
 
 REFRESH_INTERVAL_IN_MILLIS = 3000
 EXPERIMENTS_PAGE_SIZE = 6
@@ -274,7 +274,7 @@ def register_callbacks(app, dashboard_data_reader):
 
     def build_remove_button(plot_id, color):
         return dbc.Button(
-            f"{plot_id} ✖️",
+            f" ✖️ {plot_id}",
             style={"background-color": color},
             class_name="remove-button",
             id={"type": "remove-button", "index": plot_id},

--- a/entropylab/dashboard/pages/results/callbacks.py
+++ b/entropylab/dashboard/pages/results/callbacks.py
@@ -96,7 +96,7 @@ def register_callbacks(app, dashboard_data_reader):
         Output("figures-by-key", "data"),
         Output("prev-selected-rows", "data"),
         Output("failed-plotting-alert", "children"),
-        Output("no-paging-spacer", "hidden"),
+        Output("add-button", "disabled"),
         Input("experiments-table", "selected_rows"),
         State("experiments-table", "data"),
         State("figures-by-key", "data"),
@@ -111,7 +111,7 @@ def register_callbacks(app, dashboard_data_reader):
         prev_selected_rows = prev_selected_rows or {}
         alert_text = ""
         added_row = get_added_row(prev_selected_rows, selected_rows)
-        spacer_hidden = len(data) > EXPERIMENTS_PAGE_SIZE
+        add_button_disabled = False
         if data and selected_rows:
             for row_num in selected_rows:
                 alert_on_fail = row_num == added_row
@@ -151,7 +151,14 @@ def register_callbacks(app, dashboard_data_reader):
                         )
         if len(result) == 0:
             result = [build_plot_tabs_placeholder()]
-        return result, figures_by_key, selected_rows, alert_text, spacer_hidden
+            add_button_disabled = True
+        return (
+            result,
+            figures_by_key,
+            selected_rows,
+            alert_text,
+            add_button_disabled,
+        )
 
     def build_plot_tabs(
         alert_on_fail, failed_plot_ids, figures_by_key, plots_and_figures, result
@@ -274,7 +281,14 @@ def register_callbacks(app, dashboard_data_reader):
 
     def build_remove_button(plot_id, color):
         return dbc.Button(
-            f" ✖️ {plot_id}",
+            dbc.Row(
+                children=[
+                    dbc.Col(
+                        "✖",
+                    ),
+                    dbc.Col(f"{plot_id}", className="remove-button-label"),
+                ],
+            ),
             style={"background-color": color},
             class_name="remove-button",
             id={"type": "remove-button", "index": plot_id},

--- a/entropylab/dashboard/pages/results/layout.py
+++ b/entropylab/dashboard/pages/results/layout.py
@@ -63,7 +63,6 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                             [
                                 html.H5("Experiments", id="experiments-title"),
                                 (table(records)),
-                                html.Div(id="no-paging-spacer"),
                             ],
                             width="5",
                         ),
@@ -71,9 +70,7 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                             [
                                 dbc.Row(
                                     [
-                                        html.H5(
-                                            "Plots and Figures", id="experiments-title"
-                                        ),
+                                        html.H5("Plots and Figures", id="plots-title"),
                                         dbc.Tabs(
                                             id="plot-tabs",
                                         ),
@@ -131,7 +128,7 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                             ],
                             width="7",
                         ),
-                    ]
+                    ],
                 ),
                 footer(),
             ],

--- a/entropylab/dashboard/pages/results/layout.py
+++ b/entropylab/dashboard/pages/results/layout.py
@@ -1,14 +1,14 @@
 import dash_bootstrap_components as dbc
-import pkg_resources
 from dash import html, dcc
 
+from entropylab.dashboard.pages.components.footer import footer
+from entropylab.dashboard.pages.components.top_bar import top_bar
 from entropylab.dashboard.pages.results.dashboard_data import (
     DashboardDataReader,
 )
 from entropylab.dashboard.pages.results.table import table
 from entropylab.pipeline.results_backend.sqlalchemy.project import (
     project_name,
-    project_path,
 )
 
 REFRESH_INTERVAL_IN_MILLIS = 3000
@@ -39,13 +39,15 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                     [
                         dbc.ModalHeader(
                             dbc.ModalTitle(
-                                f"ℹ️ Project '{project_name(path)}' contains no experiments"
+                                f"ℹ️ Project '{project_name(path)}' contains no "
+                                f"experiments"
                             ),
                             close_button=False,
                         ),
                         dbc.ModalBody(
-                            "As soon as experiments are saved to the project this notice "
-                            "will be closed and the experiments will be shown below."
+                            "As soon as experiments are saved to the project this "
+                            "notice will be closed and the experiments will be shown "
+                            "below."
                         ),
                         dbc.ModalFooter(),
                     ],
@@ -54,63 +56,7 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                     centered=True,
                     is_open=False,
                 ),
-                dbc.Row(
-                    dbc.Navbar(
-                        [
-                            dbc.Col(
-                                dbc.NavbarBrand(
-                                    html.Img(
-                                        src="/assets/images/entropy_logo_dark.svg",
-                                        width=150,
-                                        id="entropy-logo",
-                                    ),
-                                    href="#",
-                                ),
-                                width="2",
-                                id="logo-col",
-                            ),
-                            dbc.Col(
-                                [
-                                    html.Div(
-                                        f"Project: {project_name(path)}",
-                                        id="project-name",
-                                    ),
-                                    html.Div(
-                                        f"{project_path(path)}",
-                                        id="project-name",
-                                        style={"fontSize": "11px"},
-                                    ),
-                                    html.Div(
-                                        f"entropylab version: {pkg_resources.get_distribution('entropylab').version}"
-                                    ),
-                                ],
-                                width="4",
-                            ),
-                            dbc.Col(
-                                dbc.Row(
-                                    [
-                                        dbc.Col(
-                                            dbc.NavItem(
-                                                dbc.NavLink(
-                                                    "Experiment Results",
-                                                    href="/",
-                                                    active=True,
-                                                )
-                                            )
-                                        ),
-                                        dbc.Col(
-                                            dbc.NavItem(
-                                                dbc.NavLink("Params", href="/params")
-                                            )
-                                        ),
-                                    ]
-                                ),
-                                width="6",
-                            ),
-                        ],
-                        color="primary",
-                    ),
-                ),
+                top_bar(path),
                 dbc.Row(
                     [
                         dbc.Col(
@@ -187,64 +133,7 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                         ),
                     ]
                 ),
-                # dbc.Row(
-                #     [
-                #         dbc.Col(
-                #             (
-                #                 dbc.Tabs(
-                #                     id="plot-tabs",
-                #                 ),
-                #             ),
-                #             width="5",
-                #         ),
-                #         dbc.Col(
-                #             html.Div(
-                #                 dbc.Button(
-                #                     "Add >>",
-                #                     id="add-button",
-                #                 ),
-                #                 className="add-button-col-container",
-                #             ),
-                #             width="1",
-                #             className="add-button-col",
-                #         ),
-                #         dbc.Col(
-                #             [
-                #                 dbc.Tabs(
-                #                     id="aggregate-tabs",
-                #                     children=[
-                #                         dbc.Tab(
-                #                             "",
-                #                             label="Aggregate",
-                #                             id="aggregate-tab",
-                #                         )
-                #                     ],
-                #                     persistence=True,
-                #                 ),
-                #                 dbc.Button(
-                #                     [
-                #                         "Copy Data to Clipboard",
-                #                         dcc.Clipboard(
-                #                             title="Copy data to clipboard",
-                #                             id="aggregate-clipboard",
-                #                             className="position-absolute start-0 top-0 "
-                #                             "h-100 w-100 opacity-0",
-                #                         ),
-                #                     ],
-                #                     id="copy-data-button",
-                #                     color="primary",
-                #                 ),
-                #             ],
-                #             id="aggregate-container",
-                #             width="5",
-                #         ),
-                #         dbc.Col(
-                #             [
-                #                 html.Div("<< Remove", id="remove-title"),
-                #                 html.Div(id="remove-buttons"),
-                #             ],
-                #             width="1",
-                #         ),
+                footer(),
             ],
         ),
     )

--- a/entropylab/dashboard/pages/results/layout.py
+++ b/entropylab/dashboard/pages/results/layout.py
@@ -1,4 +1,5 @@
 import dash_bootstrap_components as dbc
+import pkg_resources
 from dash import html, dcc
 
 from entropylab.dashboard.pages.results.dashboard_data import (
@@ -77,6 +78,7 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                                     id="project-name",
                                     style={"fontSize": "11px"},
                                 ),
+                                html.Div(f"entropylab version: {pkg_resources.get_distribution('entropylab').version}")
                             ],
                             width="4",
                         ),
@@ -105,25 +107,23 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                     color="primary",
                 ),
             ),
-            dbc.Row(
+            dbc.Row([
                 dbc.Col(
                     [
                         html.H5("Experiments", id="experiments-title"),
                         (table(records)),
                         html.Div(id="no-paging-spacer"),
                     ],
-                    width="12",
-                )
-            ),
-            dbc.Row(
-                [
+                    width="4",
+                ),
+                dbc.Col([
                     dbc.Col(
                         (
                             dbc.Tabs(
                                 id="plot-tabs",
                             ),
                         ),
-                        width="5",
+                        width="8",
                     ),
                     dbc.Col(
                         html.Div(
@@ -156,7 +156,7 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                                         title="Copy data to clipboard",
                                         id="aggregate-clipboard",
                                         className="position-absolute start-0 top-0 "
-                                        "h-100 w-100 opacity-0",
+                                                  "h-100 w-100 opacity-0",
                                     ),
                                 ],
                                 id="copy-data-button",
@@ -164,15 +164,76 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                             ),
                         ],
                         id="aggregate-container",
-                        width="5",
+                        width="8",
                     ),
-                    dbc.Col(
+                    dbc.Row(
                         [
                             html.Div("<< Remove", id="remove-title"),
                             html.Div(id="remove-buttons"),
                         ],
-                        width="1",
+
                     ),
+
+                ]), ]
+            ),
+            # dbc.Row(
+            #     [
+            #         dbc.Col(
+            #             (
+            #                 dbc.Tabs(
+            #                     id="plot-tabs",
+            #                 ),
+            #             ),
+            #             width="5",
+            #         ),
+            #         dbc.Col(
+            #             html.Div(
+            #                 dbc.Button(
+            #                     "Add >>",
+            #                     id="add-button",
+            #                 ),
+            #                 className="add-button-col-container",
+            #             ),
+            #             width="1",
+            #             className="add-button-col",
+            #         ),
+            #         dbc.Col(
+            #             [
+            #                 dbc.Tabs(
+            #                     id="aggregate-tabs",
+            #                     children=[
+            #                         dbc.Tab(
+            #                             "",
+            #                             label="Aggregate",
+            #                             id="aggregate-tab",
+            #                         )
+            #                     ],
+            #                     persistence=True,
+            #                 ),
+            #                 dbc.Button(
+            #                     [
+            #                         "Copy Data to Clipboard",
+            #                         dcc.Clipboard(
+            #                             title="Copy data to clipboard",
+            #                             id="aggregate-clipboard",
+            #                             className="position-absolute start-0 top-0 "
+            #                             "h-100 w-100 opacity-0",
+            #                         ),
+            #                     ],
+            #                     id="copy-data-button",
+            #                     color="primary",
+            #                 ),
+            #             ],
+            #             id="aggregate-container",
+            #             width="5",
+            #         ),
+            #         dbc.Col(
+            #             [
+            #                 html.Div("<< Remove", id="remove-title"),
+            #                 html.Div(id="remove-buttons"),
+            #             ],
+            #             width="1",
+            #         ),
                 ]
             ),
             # Disabled temporarily. See ../../assets/custom-script.js for details.
@@ -188,5 +249,5 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
             #     labelStyle={"display": "flex"},
             #     id="success-filter-checklist",
             # ),
-        ],
-    )
+    #     ],
+    # )

--- a/entropylab/dashboard/pages/results/layout.py
+++ b/entropylab/dashboard/pages/results/layout.py
@@ -17,237 +17,255 @@ REFRESH_INTERVAL_IN_MILLIS = 3000
 def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
     records = dashboard_data_reader.get_last_experiments()
 
-    return dbc.Container(
-        fluid=True,
-        className="main",
-        children=[
-            dcc.Store(id="figures-by-key", storage_type="session"),
-            dcc.Store(id="plot-keys-to-combine", storage_type="session"),
-            dcc.Store(id="prev-selected-rows", storage_type="session"),
-            dcc.Interval(
-                id="interval", interval=REFRESH_INTERVAL_IN_MILLIS, n_intervals=0
-            ),
-            dbc.Alert(
-                "",
-                id="failed-plotting-alert",
-                color="warning",
-                is_open=False,
-                fade=True,
-            ),
-            dbc.Modal(
-                [
-                    dbc.ModalHeader(
-                        dbc.ModalTitle(
-                            f"ℹ️ Project '{project_name(path)}' contains no experiments"
+    return (
+        dbc.Container(
+            fluid=True,
+            className="main",
+            children=[
+                dcc.Store(id="figures-by-key", storage_type="session"),
+                dcc.Store(id="plot-keys-to-combine", storage_type="session"),
+                dcc.Store(id="prev-selected-rows", storage_type="session"),
+                dcc.Interval(
+                    id="interval", interval=REFRESH_INTERVAL_IN_MILLIS, n_intervals=0
+                ),
+                dbc.Alert(
+                    "",
+                    id="failed-plotting-alert",
+                    color="warning",
+                    is_open=False,
+                    fade=True,
+                ),
+                dbc.Modal(
+                    [
+                        dbc.ModalHeader(
+                            dbc.ModalTitle(
+                                f"ℹ️ Project '{project_name(path)}' contains no experiments"
+                            ),
+                            close_button=False,
                         ),
-                        close_button=False,
+                        dbc.ModalBody(
+                            "As soon as experiments are saved to the project this notice "
+                            "will be closed and the experiments will be shown below."
+                        ),
+                        dbc.ModalFooter(),
+                    ],
+                    id="empty-project-modal",
+                    backdrop="static",
+                    centered=True,
+                    is_open=False,
+                ),
+                dbc.Row(
+                    dbc.Navbar(
+                        [
+                            dbc.Col(
+                                dbc.NavbarBrand(
+                                    html.Img(
+                                        src="/assets/images/entropy_logo_dark.svg",
+                                        width=150,
+                                        id="entropy-logo",
+                                    ),
+                                    href="#",
+                                ),
+                                width="2",
+                                id="logo-col",
+                            ),
+                            dbc.Col(
+                                [
+                                    html.Div(
+                                        f"Project: {project_name(path)}",
+                                        id="project-name",
+                                    ),
+                                    html.Div(
+                                        f"{project_path(path)}",
+                                        id="project-name",
+                                        style={"fontSize": "11px"},
+                                    ),
+                                    html.Div(
+                                        f"entropylab version: {pkg_resources.get_distribution('entropylab').version}"
+                                    ),
+                                ],
+                                width="4",
+                            ),
+                            dbc.Col(
+                                dbc.Row(
+                                    [
+                                        dbc.Col(
+                                            dbc.NavItem(
+                                                dbc.NavLink(
+                                                    "Experiment Results",
+                                                    href="/",
+                                                    active=True,
+                                                )
+                                            )
+                                        ),
+                                        dbc.Col(
+                                            dbc.NavItem(
+                                                dbc.NavLink("Params", href="/params")
+                                            )
+                                        ),
+                                    ]
+                                ),
+                                width="6",
+                            ),
+                        ],
+                        color="primary",
                     ),
-                    dbc.ModalBody(
-                        "As soon as experiments are saved to the project this notice "
-                        "will be closed and the experiments will be shown below."
-                    ),
-                    dbc.ModalFooter(),
-                ],
-                id="empty-project-modal",
-                backdrop="static",
-                centered=True,
-                is_open=False,
-            ),
-            dbc.Row(
-                dbc.Navbar(
+                ),
+                dbc.Row(
                     [
                         dbc.Col(
-                            dbc.NavbarBrand(
-                                html.Img(
-                                    src="/assets/images/entropy_logo_dark.svg",
-                                    width=150,
-                                    id="entropy-logo",
-                                ),
-                                href="#",
-                            ),
-                            width="2",
-                            id="logo-col",
+                            [
+                                html.H5("Experiments", id="experiments-title"),
+                                (table(records)),
+                                html.Div(id="no-paging-spacer"),
+                            ],
+                            width="5",
                         ),
                         dbc.Col(
                             [
-                                html.Div(
-                                    f"Project: {project_name(path)}", id="project-name"
+                                dbc.Row(
+                                    [
+                                        html.H5(
+                                            "Plots and Figures", id="experiments-title"
+                                        ),
+                                        dbc.Tabs(
+                                            id="plot-tabs",
+                                        ),
+                                    ]
+                                    # width="8",
                                 ),
-                                html.Div(
-                                    f"{project_path(path)}",
-                                    id="project-name",
-                                    style={"fontSize": "11px"},
+                                dbc.Row(
+                                    html.Div(
+                                        dbc.Button(
+                                            "Add Plot to Aggregate View",
+                                            id="add-button",
+                                        ),
+                                        className="add-button-col-container",
+                                    ),
+                                    # width="1",
+                                    className="add-button-col",
                                 ),
-                                html.Div(f"entropylab version: {pkg_resources.get_distribution('entropylab').version}")
+                                dbc.Row(
+                                    [
+                                        html.H5(
+                                            "Aggregate View", id="experiments-title"
+                                        ),
+                                        dbc.Tabs(
+                                            id="aggregate-tabs",
+                                            children=[
+                                                dbc.Tab(
+                                                    "",
+                                                    label="",
+                                                    id="aggregate-tab",
+                                                )
+                                            ],
+                                            persistence=True,
+                                        ),
+                                        dbc.Button(
+                                            [
+                                                "Copy Data to Clipboard",
+                                                dcc.Clipboard(
+                                                    title="Copy data to clipboard",
+                                                    id="aggregate-clipboard",
+                                                    className="position-absolute "
+                                                    "start-0 top-0 "
+                                                    "h-100 w-100 opacity-0",
+                                                ),
+                                            ],
+                                            id="copy-data-button",
+                                            color="primary",
+                                        ),
+                                    ],
+                                    id="aggregate-container",
+                                    # width="8",
+                                ),
+                                dbc.Row(
+                                    [
+                                        html.Div(
+                                            "Remove Plots from Aggregate View",
+                                            id="remove-title",
+                                        ),
+                                        html.Div(id="remove-buttons"),
+                                    ],
+                                ),
                             ],
-                            width="4",
+                            width="7",
                         ),
-                        dbc.Col(
-                            dbc.Row(
-                                [
-                                    dbc.Col(
-                                        dbc.NavItem(
-                                            dbc.NavLink(
-                                                "Experiment Results",
-                                                href="/",
-                                                active=True,
-                                            )
-                                        )
-                                    ),
-                                    dbc.Col(
-                                        dbc.NavItem(
-                                            dbc.NavLink("Params", href="/params")
-                                        )
-                                    ),
-                                ]
-                            ),
-                            width="6",
-                        ),
-                    ],
-                    color="primary",
+                    ]
                 ),
-            ),
-            dbc.Row([
-                dbc.Col(
-                    [
-                        html.H5("Experiments", id="experiments-title"),
-                        (table(records)),
-                        html.Div(id="no-paging-spacer"),
-                    ],
-                    width="4",
-                ),
-                dbc.Col([
-                    dbc.Col(
-                        (
-                            dbc.Tabs(
-                                id="plot-tabs",
-                            ),
-                        ),
-                        width="8",
-                    ),
-                    dbc.Col(
-                        html.Div(
-                            dbc.Button(
-                                "Add >>",
-                                id="add-button",
-                            ),
-                            className="add-button-col-container",
-                        ),
-                        width="1",
-                        className="add-button-col",
-                    ),
-                    dbc.Col(
-                        [
-                            dbc.Tabs(
-                                id="aggregate-tabs",
-                                children=[
-                                    dbc.Tab(
-                                        "",
-                                        label="Aggregate",
-                                        id="aggregate-tab",
-                                    )
-                                ],
-                                persistence=True,
-                            ),
-                            dbc.Button(
-                                [
-                                    "Copy Data to Clipboard",
-                                    dcc.Clipboard(
-                                        title="Copy data to clipboard",
-                                        id="aggregate-clipboard",
-                                        className="position-absolute start-0 top-0 "
-                                                  "h-100 w-100 opacity-0",
-                                    ),
-                                ],
-                                id="copy-data-button",
-                                color="primary",
-                            ),
-                        ],
-                        id="aggregate-container",
-                        width="8",
-                    ),
-                    dbc.Row(
-                        [
-                            html.Div("<< Remove", id="remove-title"),
-                            html.Div(id="remove-buttons"),
-                        ],
-
-                    ),
-
-                ]), ]
-            ),
-            # dbc.Row(
-            #     [
-            #         dbc.Col(
-            #             (
-            #                 dbc.Tabs(
-            #                     id="plot-tabs",
-            #                 ),
-            #             ),
-            #             width="5",
-            #         ),
-            #         dbc.Col(
-            #             html.Div(
-            #                 dbc.Button(
-            #                     "Add >>",
-            #                     id="add-button",
-            #                 ),
-            #                 className="add-button-col-container",
-            #             ),
-            #             width="1",
-            #             className="add-button-col",
-            #         ),
-            #         dbc.Col(
-            #             [
-            #                 dbc.Tabs(
-            #                     id="aggregate-tabs",
-            #                     children=[
-            #                         dbc.Tab(
-            #                             "",
-            #                             label="Aggregate",
-            #                             id="aggregate-tab",
-            #                         )
-            #                     ],
-            #                     persistence=True,
-            #                 ),
-            #                 dbc.Button(
-            #                     [
-            #                         "Copy Data to Clipboard",
-            #                         dcc.Clipboard(
-            #                             title="Copy data to clipboard",
-            #                             id="aggregate-clipboard",
-            #                             className="position-absolute start-0 top-0 "
-            #                             "h-100 w-100 opacity-0",
-            #                         ),
-            #                     ],
-            #                     id="copy-data-button",
-            #                     color="primary",
-            #                 ),
-            #             ],
-            #             id="aggregate-container",
-            #             width="5",
-            #         ),
-            #         dbc.Col(
-            #             [
-            #                 html.Div("<< Remove", id="remove-title"),
-            #                 html.Div(id="remove-buttons"),
-            #             ],
-            #             width="1",
-            #         ),
-                ]
-            ),
-            # Disabled temporarily. See ../../assets/custom-script.js for details.
-            # dcc.Checklist(
-            #     [
-            #         {"label": "✔️", "value": True},
-            #         {"label": "❌", "value": False},
-            #     ],
-            #     [True, False],
-            #     inline=False,
-            #     inputClassName="success-filter-checklist-input",
-            #     labelClassName="success-filter-checklist-label",
-            #     labelStyle={"display": "flex"},
-            #     id="success-filter-checklist",
-            # ),
+                # dbc.Row(
+                #     [
+                #         dbc.Col(
+                #             (
+                #                 dbc.Tabs(
+                #                     id="plot-tabs",
+                #                 ),
+                #             ),
+                #             width="5",
+                #         ),
+                #         dbc.Col(
+                #             html.Div(
+                #                 dbc.Button(
+                #                     "Add >>",
+                #                     id="add-button",
+                #                 ),
+                #                 className="add-button-col-container",
+                #             ),
+                #             width="1",
+                #             className="add-button-col",
+                #         ),
+                #         dbc.Col(
+                #             [
+                #                 dbc.Tabs(
+                #                     id="aggregate-tabs",
+                #                     children=[
+                #                         dbc.Tab(
+                #                             "",
+                #                             label="Aggregate",
+                #                             id="aggregate-tab",
+                #                         )
+                #                     ],
+                #                     persistence=True,
+                #                 ),
+                #                 dbc.Button(
+                #                     [
+                #                         "Copy Data to Clipboard",
+                #                         dcc.Clipboard(
+                #                             title="Copy data to clipboard",
+                #                             id="aggregate-clipboard",
+                #                             className="position-absolute start-0 top-0 "
+                #                             "h-100 w-100 opacity-0",
+                #                         ),
+                #                     ],
+                #                     id="copy-data-button",
+                #                     color="primary",
+                #                 ),
+                #             ],
+                #             id="aggregate-container",
+                #             width="5",
+                #         ),
+                #         dbc.Col(
+                #             [
+                #                 html.Div("<< Remove", id="remove-title"),
+                #                 html.Div(id="remove-buttons"),
+                #             ],
+                #             width="1",
+                #         ),
+            ],
+        ),
+    )
+    # Disabled temporarily. See ../../assets/custom-script.js for details.
+    # dcc.Checklist(
+    #     [
+    #         {"label": "✔️", "value": True},
+    #         {"label": "❌", "value": False},
+    #     ],
+    #     [True, False],
+    #     inline=False,
+    #     inputClassName="success-filter-checklist-input",
+    #     labelClassName="success-filter-checklist-label",
+    #     labelStyle={"display": "flex"},
+    #     id="success-filter-checklist",
+    # ),
     #     ],
     # )

--- a/entropylab/dashboard/pages/results/layout.py
+++ b/entropylab/dashboard/pages/results/layout.py
@@ -132,18 +132,13 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                                             id="plot-tabs",
                                         ),
                                     ]
-                                    # width="8",
                                 ),
                                 dbc.Row(
-                                    html.Div(
-                                        dbc.Button(
-                                            "Add Plot to Aggregate View",
-                                            id="add-button",
-                                        ),
-                                        className="add-button-col-container",
+                                    dbc.Button(
+                                        "➕ Add Plot to Aggregate View",
+                                        id="add-button",
                                     ),
-                                    # width="1",
-                                    className="add-button-col",
+                                    className="add-button-container",
                                 ),
                                 dbc.Row(
                                     [
@@ -163,13 +158,13 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                                         ),
                                         dbc.Button(
                                             [
-                                                "Copy Data to Clipboard",
+                                                " Copy Data to Clipboard",
                                                 dcc.Clipboard(
                                                     title="Copy data to clipboard",
                                                     id="aggregate-clipboard",
                                                     className="position-absolute "
-                                                    "start-0 top-0 "
-                                                    "h-100 w-100 opacity-0",
+                                                    # "start-0 top-0 "
+                                                    # "h-100 w-100 opacity-0",
                                                 ),
                                             ],
                                             id="copy-data-button",
@@ -177,12 +172,11 @@ def build_layout(path: str, dashboard_data_reader: DashboardDataReader):
                                         ),
                                     ],
                                     id="aggregate-container",
-                                    # width="8",
                                 ),
                                 dbc.Row(
                                     [
                                         html.Div(
-                                            "Remove Plots from Aggregate View",
+                                            "Click to remove from Aggregate View:",
                                             id="remove-title",
                                         ),
                                         html.Div(id="remove-buttons"),

--- a/entropylab/dashboard/pages/results/table.py
+++ b/entropylab/dashboard/pages/results/table.py
@@ -35,15 +35,12 @@ def table(records):
         style_header=table_style_header,
         style_cell=table_style_cell,
         style_cell_conditional=[
-            {"if": {"column_id": "id"}, "width": "7%"},
-            {"if": {"column_id": "label"}, "width": "30%"},
-            {
-                "if": {"column_id": "start_time"},
-                "width": "18%",
-            },
-            {"if": {"column_id": "end_time"}, "width": "18%"},
-            {"if": {"column_id": "user"}, "width": "17%"},
-            {"if": {"column_id": "success"}, "width": "10%"},
+            {"if": {"column_id": "id"}, "width": "9%"},
+            {"if": {"column_id": "label"}, "width": "20%"},
+            {"if": {"column_id": "start_time"}, "width": "26%"},
+            {"if": {"column_id": "end_time"}, "width": "26%"},
+            {"if": {"column_id": "user"}, "width": "13%"},
+            {"if": {"column_id": "success"}, "width": "6%"},
         ],
         style_data_conditional=[
             {

--- a/entropylab/dashboard/pages/results/table.py
+++ b/entropylab/dashboard/pages/results/table.py
@@ -7,7 +7,7 @@ from entropylab.dashboard.theme import (
     table_style_cell,
 )
 
-EXPERIMENTS_PAGE_SIZE = 6
+EXPERIMENTS_PAGE_SIZE = 36
 
 
 def table(records):
@@ -19,7 +19,7 @@ def table(records):
             dict(name="start_time", id="start_time", type="datetime"),
             dict(name="end_time", id="end_time", type="datetime"),
             dict(name="user", id="user", type="text"),
-            dict(name="success", id="success"),
+            # dict(name="success", id="success"),
         ],
         data=records,
         persistence=True,

--- a/entropylab/dashboard/pages/results/table.py
+++ b/entropylab/dashboard/pages/results/table.py
@@ -7,8 +7,6 @@ from entropylab.dashboard.theme import (
     table_style_cell,
 )
 
-EXPERIMENTS_PAGE_SIZE = 36
-
 
 def table(records):
     tbl = dash_table.DataTable(
@@ -28,8 +26,6 @@ def table(records):
         cell_selectable=False,
         sort_action="native",
         filter_action="native",
-        page_action="native",
-        page_size=EXPERIMENTS_PAGE_SIZE,
         style_data=table_style_data,
         style_filter=table_style_filter,
         style_header=table_style_header,


### PR DESCRIPTION
This PR changes the layout of the "experiment results" in the Entropy Dashboard. The list of experiments is now shown on the left-hand side of the page and spans its full height. The plot tabs and the aggregate tabs are placed on the right hand tab, one on top of the other.