### PR TITLE
Expiration for ParamStore Params

### DIFF
--- a/entropylab/pipeline/api/in_process_param_store.py
+++ b/entropylab/pipeline/api/in_process_param_store.py
@@ -8,7 +8,7 @@ import shutil
 import string
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from random import SystemRandom
 from typing import Optional, Dict, Any, List, Callable, Set
@@ -223,6 +223,27 @@ class InProcessParamStore(ParamStore):
             else:
                 commit = self.__get_commit(commit_id)
                 return copy.deepcopy(commit["params"][key])
+
+    def set_param(self,
+                  key: str,
+                  value: object,
+                  expiration: Optional[timedelta]):
+        # if not value and not expiration:
+        #     raise EntropyError("method set_param() requires at least one of the "
+        #                        "arguments: value or expiration")
+        with self.__lock:
+            if key in self.__params:
+                param = self.get_param(key)
+            else:
+                param = Param(value)
+            param.value = value
+            if expiration:
+                param.expiration = expiration
+            else:
+                param.expiration = None
+            self.__params.__setitem__(key, param)
+            self.__is_dirty = True
+            self.__dirty_keys.add(key)
 
     def __remove_key_from_tags(self, key: str):
         for tag in self.__tags:

--- a/entropylab/pipeline/api/param_store.py
+++ b/entropylab/pipeline/api/param_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from enum import Enum, unique
@@ -26,7 +27,7 @@ class ParamStore(ABC, MutableMapping):
     @abstractmethod
     def get_value(self, key: str, commit_id: Optional[str] = None) -> object:
         """
-            returns the value of a param by its key
+        Returns the value of a param by its key
 
         :param key: the key identifying the param
         :param commit_id: an optional commit_id. If provided, the value will be
@@ -37,11 +38,24 @@ class ParamStore(ABC, MutableMapping):
     @abstractmethod
     def get_param(self, key: str, commit_id: Optional[str] = None) -> Param:
         """
-            returns a copy of the Param instance of a value stored in ParamStore
+        Returns a copy of the Param instance of a value stored in ParamStore
 
         :param key: the key identifying the param
         :param commit_id: an optional commit_id. If provided, the Param will be
         returned from the specified commit
+        """
+        pass
+
+    @abstractmethod
+    def set_param(self, key: str, value: object, expiration: Optional[timedelta]):
+        """
+        Sets a Param in the ParamStore
+
+        :param key: the key identifying the param
+        :param value: the value of the param
+        :param key: an optional period of time (measured from the time the param
+        is committed) after which the prime expires (i.e. param.has_expired
+        returns True)
         """
         pass
 
@@ -60,7 +74,7 @@ class ParamStore(ABC, MutableMapping):
     @abstractmethod
     def list_commits(self, label: Optional[str]):
         """
-            returns a list of commits
+        Returns a list of commits
 
         :param label: an optional label, if given then only commits that match
         it will be returned
@@ -70,8 +84,8 @@ class ParamStore(ABC, MutableMapping):
     @abstractmethod
     def list_values(self, key: str) -> pd.DataFrame:
         """
-            list all the values of a given key taken from commit history,
-            sorted by date ascending
+        Lists all the values of a given key taken from commit history,
+        sorted by date ascending
 
         :param key: the key for which to list values
         :returns: a list of tuples where the values are, in order:
@@ -121,7 +135,8 @@ class ParamStore(ABC, MutableMapping):
     @property
     @abstractmethod
     def is_dirty(self):
-        """True iff params have been changed since the store has last been
+        """
+        True iff params have been changed since the store has last been
         initialized or checked out"""
         pass
 
@@ -130,10 +145,36 @@ class Param(Dict):
     def __init__(self, value):
         super().__init__()
         self.value: object = value
-        self.commit_id: str = None
-        self.expiration: timedelta = None
+        self.commit_id: Optional[str] = None
+        self.expiration: Optional[timedelta | int] = None
 
     def __repr__(self):
-        return f"<Param(value={self.value}, " \
-               f"commit_id={self.commit_id}, " \
-               f"expiration={self.expiration})> "
+        return (
+            f"<Param(value={self.value}, "
+            f"commit_id={self.commit_id}, "
+            f"expiration={self.__expiration_repr})> "
+        )
+
+    @property
+    def __expiration_repr(self):
+        if isinstance(self.expiration, int):
+            return _ns_to_datetime(self.expiration)
+        else:
+            return False
+
+    @property
+    def has_expired(self):
+        """
+        Indicates whether the Param value has expired. Returns True iff the Param
+        has been committed and the time elapsed since the commit operation has exceeded
+        the time recorded in the `expiration` property"""
+        if isinstance(self.expiration, int):
+            return self.expiration < time.time_ns()
+        else:
+            return False
+
+
+def _ns_to_datetime(ns: int) -> pd.datetime:
+    """
+    Converts a UNIX epoch timestamp in nano-seconds to a human readable string"""
+    return pd.to_datetime(ns)

--- a/entropylab/pipeline/api/param_store.py
+++ b/entropylab/pipeline/api/param_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from enum import Enum, unique
 from typing import Dict, List, Optional, MutableMapping
 
@@ -128,8 +129,11 @@ class ParamStore(ABC, MutableMapping):
 class Param(Dict):
     def __init__(self, value):
         super().__init__()
-        self.value = value
-        self.commit_id = None
+        self.value: object = value
+        self.commit_id: str = None
+        self.expiration: timedelta = None
 
     def __repr__(self):
-        return f"<Param(value={self.value}, commit_id={self.commit_id})>"
+        return f"<Param(value={self.value}, " \
+               f"commit_id={self.commit_id}, " \
+               f"expiration={self.expiration})> "

--- a/entropylab/pipeline/tests/test_param_store.py
+++ b/entropylab/pipeline/tests/test_param_store.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from pprint import pprint
 from time import sleep
 
@@ -234,6 +235,52 @@ def test_get_param_when_commit_id_is_bad_then_entropy_error_is_raised():
     # act
     with pytest.raises(EntropyError):
         target.get_param("foo", "oops")
+
+
+""" set_param() """
+
+
+def test_set_param_when_param_is_new_then_value_is_set():
+    # arrange
+    target = InProcessParamStore()
+    target.set_param("foo", "bar", timedelta(seconds=42))
+    # act
+    assert target["foo"] == "bar"
+
+
+def test_set_param_when_param_is_new_then_expiration_is_set():
+    # arrange
+    target = InProcessParamStore()
+    target.set_param("foo", "bar", timedelta(seconds=42))
+    # act
+    assert target.get_param("foo").expiration == timedelta(seconds=42)
+
+
+def test_set_param_exists_then_value_is_overwritten():
+    # arrange
+    target = InProcessParamStore()
+    target.foo = "bar"
+    target.set_param("foo", "baz", timedelta(seconds=42))
+    # act
+    assert target.foo == "baz"
+
+
+def test_set_param_exists_then_expiration_is_overwritten():
+    # arrange
+    target = InProcessParamStore()
+    target.set_param("foo", "bar", timedelta(minutes=90))
+    target.set_param("foo", "bar", timedelta(seconds=42))
+    # act
+    assert target.get_param("foo").expiration == timedelta(seconds=42)
+
+
+def test_set_param_exists_and_expiration_is_none_then_expiration_is_none():
+    # arrange
+    target = InProcessParamStore()
+    target.set_param("foo", "bar", timedelta(minutes=90))
+    target.set_param("foo", "bar", None)
+    # act
+    assert not target.get_param("foo").expiration
 
 
 """ rename_key() """


### PR DESCRIPTION
This PR adds expiration functionality to `ParamStore` `Param`s.

Users can now set an `expiration` property on a `Param` instance to a `timedelta`.
Users can then get a `has_expired` property which will return True if and only if the `Param` has been committed and if the `expiration` has been set and the time since the commit operation exceeds it (the `expiration` delta).