### PR TITLE
Dashboard - Make waitress logger print host and port to stdout on serve

### DIFF
--- a/entropylab/dashboard/__init__.py
+++ b/entropylab/dashboard/__init__.py
@@ -31,14 +31,14 @@ def serve_dashboard(
     # debug mode
     if debug:
         file_handler = _create_file_handler(dashboard_log_path(path))
-
         _set_to_debug(logger, file_handler)
         _set_to_debug(logging.getLogger("waitress"), file_handler)
         _set_to_debug(logging.getLogger("hupper"), file_handler)
-
         hupper_logger = HupperLogger(logging.DEBUG)
     else:
-        hupper_logger = None
+        logger.setLevel(logging.INFO)
+        logging.getLogger("waitress").setLevel(logging.INFO)
+        hupper_logger = HupperLogger(logging.INFO)
 
     # defaults for args
     if host is None:


### PR DESCRIPTION
This PR resolves issue https://github.com/entropy-lab/entropy/issues/134 to make the Entropy CLI's `serve` command print the host name and port number when it commences running.

The PR changes the logging level of the `waitress` and `hupper` logger to INFO.