### PR TITLE
Fixing high CPU issue when running the dashboard

### DIFF
--- a/entropylab/dashboard/__init__.py
+++ b/entropylab/dashboard/__init__.py
@@ -61,7 +61,7 @@ def serve_dashboard(
     hupper.start_reloader(
         "entropylab.dashboard.serve_dashboard",
         worker_kwargs=worker_kwargs,
-        reload_interval=0,
+        reload_interval=1,
         logger=hupper_logger,
     )
 


### PR DESCRIPTION
This PR fixes an issue reported by @liorella-qm: When running the dashboard in Linux, it consumes nearly 100% CPU. See here for how to recreate: https://github.com/Pylons/hupper/issues/75

The root cause of the issue is that the hupper package used in the dashboard `__init__.py` file to hot-reload `waitress` is set to have `reload_interval=0`. This seems to be performing badly on Linux.

The remedy provided by this PR is to simply set the refresh interval value to 1. 

In the future we may consider integrating `[watchdog](https://pypi.org/project/watchdog/)` on top of `hupper` as [documentation ](https://docs.pylonsproject.org/projects/hupper/en/latest/#polling)suggests it is a more robust solution for listening to file system events than `hupper`'s built-in polling mechanism.