### PR TITLE
Flame single node workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+### Changed
+
+### Added
+* Flame: Support for saving single node dry-runs into EntropyHub
 
 ## [0.11.2]
 ### Fixed

--- a/entropylab/flame/inputs.py
+++ b/entropylab/flame/inputs.py
@@ -137,7 +137,7 @@ class Inputs:
                     f"{nodeio_context.node_name}/{name} is reached, "
                     "terminating test run of the node."
                 )
-                exit()
+                nodeio_context.terminate_node()
             if self.input_type[name] == InputType.STREAM:
                 print(f"\tENTROPYLAB - STREAM INPUT {nodeio_context.node_name}/{name}")
             else:
@@ -309,10 +309,22 @@ class Inputs:
             self.value_set[name] = False
 
     def reset_all(self):
-        """Resets all set input values to not set, keeping the input variable"""
+        """Resets all set input values to not set, keeping the input variable."""
+        if nodeio_context.entropy_identity is None:
+            return
         for name, _value in self.values.items():
             self.values[name] = None
             self.value_set[name] = False
+
+    def reset_all_dry_run_data(self):
+        """Resets dry-run data only, keeping inputs untouched if they are part
+        of the workflow. Useful when authoring node interactively in Jupyter
+        nodebook, when set might be called repeatedly by executing corresponding
+        Jupyter notebook cell."""
+        if nodeio_context.entropy_identity is None:
+            return
+        else:
+            self.reset_all()
 
     def defines(self, name):
         """Returns true if input exists and it is defined."""

--- a/entropylab/flame/nodeio_context.py
+++ b/entropylab/flame/nodeio_context.py
@@ -1,5 +1,8 @@
 import zmq
 import json
+import os
+import subprocess
+import platform
 from sqlalchemy import create_engine
 
 __all__ = [
@@ -73,10 +76,24 @@ def is_IPython():
 
 
 def terminate_node():
-    if save_dry_run:
+    if save_dry_run and runtime_data is None:
         with open("dry_run_data.json", "w") as outfile:
             json.dump(dry_run_data, outfile)
         dry_run_log.close()
+        # save to entropyhub
+        env = os.environ
+        env["PYTHONPATH"] = os.getcwd()
+        if platform.system() == "Windows":
+            python_cmd = "python"
+        else:
+            python_cmd = "python3"
+        subprocess.run(
+            f"{python_cmd} -m entropyhub.submit_dry_run",
+            env=env,
+            shell=True,
+            universal_newlines=True,
+            start_new_session=True,
+        )
 
     if is_IPython():
 

--- a/entropylab/flame/nodeio_context.py
+++ b/entropylab/flame/nodeio_context.py
@@ -1,4 +1,5 @@
 import zmq
+import json
 from sqlalchemy import create_engine
 
 __all__ = [
@@ -11,6 +12,11 @@ __all__ = [
     "playbook",
     "databucket",
     "data_server",
+    "save_dry_run",
+    "dry_run_data",
+    "dry_run_log",
+    "terminate_node",
+    "is_IPython",
 ]
 
 status = None
@@ -27,6 +33,10 @@ zmq_context_variable = None
 runtime_data = None
 executor_input = None  #: address of executor zmq communication channel
 executor_output = None
+
+save_dry_run = False
+dry_run_data = None
+dry_run_log = None
 
 
 def zmq_context():
@@ -47,3 +57,33 @@ def runtime_db_connect():
 
 def runtime_db_close():
     runtime_data.close()
+
+
+def is_IPython():
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell == "ZMQInteractiveShell":
+            return True  # Jupyter notebook or qtconsole
+        elif shell == "TerminalInteractiveShell":
+            return False  # Terminal running IPython
+        else:
+            return False  # Other type (?)
+    except NameError:
+        return False  # Probably standard Python interpreter
+
+
+def terminate_node():
+    if save_dry_run:
+        with open("dry_run_data.json", "w") as outfile:
+            json.dump(dry_run_data, outfile)
+        dry_run_log.close()
+
+    if is_IPython():
+
+        class StopExecution(Exception):
+            def _render_traceback_(self):
+                pass
+
+        raise StopExecution
+    else:
+        exit()

--- a/entropylab/flame/outputs.py
+++ b/entropylab/flame/outputs.py
@@ -1,5 +1,6 @@
 import zmq
 import msgpack
+import datetime
 from . import nodeio_context
 import psycopg2
 
@@ -107,6 +108,7 @@ class Outputs:
                     if key not in nodeio_context.dry_run_data["node"]["outputs"]:
                         output = {}
                         output["values"] = []
+                        output["values_time"] = []
                         output["description"] = self.description[key]
                         output["units"] = self.units[key]
                         nodeio_context.dry_run_data["node"]["outputs"][key] = output
@@ -114,6 +116,9 @@ class Outputs:
                     nodeio_context.dry_run_data["node"]["outputs"][key][
                         "values"
                     ].append(value)
+                    nodeio_context.dry_run_data["node"]["outputs"][key][
+                        "values_time"
+                    ].append(datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"))
 
         return
 

--- a/entropylab/flame/outputs.py
+++ b/entropylab/flame/outputs.py
@@ -103,6 +103,18 @@ class Outputs:
                     f" SAVE (retention = {self.retention[key]})"
                 )
                 print(f"\t{value}")
+                if nodeio_context.save_dry_run and self.retention[key] == 2:
+                    if key not in nodeio_context.dry_run_data["node"]["outputs"]:
+                        output = {}
+                        output["values"] = []
+                        output["description"] = self.description[key]
+                        output["units"] = self.units[key]
+                        nodeio_context.dry_run_data["node"]["outputs"][key] = output
+
+                    nodeio_context.dry_run_data["node"]["outputs"][key][
+                        "values"
+                    ].append(value)
+
         return
 
     # TODO: add also write that will have more controllable options when writing data

--- a/entropylab/flame/template/empty/node.py
+++ b/entropylab/flame/template/empty/node.py
@@ -9,19 +9,21 @@ nodeio.context(
 
 inputs = nodeio.Inputs()
 # define inputs
-# inputs.stream( "input name", units="units or data type", description="some detailed explanation" )
-# inputs.state(  "state input name", units="units or data type", description="some detailed explanation" )
+# inputs.stream( "input_name", units="units or data type", description="some detailed explanation" )
+# inputs.state(  "state_input_name", units="units or data type", description="some detailed explanation" )
 
 outputs = nodeio.Outputs()
 # define outputs
-# outputs.define( "output name", units="units or data type", description="some detailed explanation" )
+# outputs.define( "output_name", units="units or data type", description="some detailed explanation" )
 
 nodeio.register()
 
 # ==================== DRY RUN DATA ====================
 
+# needed just for repeated for development with repeated runs in IPython
+inputs.reset_all_dry_run_data()
+
 # set inputs data for dry-run of the node
-inputs.reset_all()  # needed just for repeated for development with repeated runs in IPython
 # inputs.set( <input_name> = <input_value>)
 
 # =============== RUN NODE STATE MACHINE ===============

--- a/entropylab/flame/template/node/node.py
+++ b/entropylab/flame/template/node/node.py
@@ -9,19 +9,21 @@ nodeio.context(
 
 inputs = nodeio.Inputs()
 # define inputs
-# inputs.stream( "input name", units="units or data type", description="some detailed explanation" )
-# inputs.state(  "state input name", units="units or data type", description="some detailed explanation" )
+# inputs.stream( "input_name", units="units or data type", description="some detailed explanation" )
+# inputs.state(  "state_input_name", units="units or data type", description="some detailed explanation" )
 
 outputs = nodeio.Outputs()
 # define outputs
-# outputs.define( "output name", units="units or data type", description="some detailed explanation" )
+# outputs.define( "output_name", units="units or data type", description="some detailed explanation" )
 
 nodeio.register()
 
 # ==================== DRY RUN DATA ====================
 
+# needed just for repeated for development with repeated runs in IPython
+inputs.reset_all_dry_run_data()
+
 # set inputs data for dry-run of the node
-inputs.reset_all()  # needed just for repeated for development with repeated runs in IPython
 # inputs.set( <input_name> = <input_value>)
 
 # =============== RUN NODE STATE MACHINE ===============


### PR DESCRIPTION
Add support for saving dry runs of individual nodes in EntropyHub with simple ` nodeio.register(save_dry_run=True)`