### PR TITLE
Flame enhancement: specify username and password for message queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Flame: Support for saving single node dry-runs into EntropyHub
+* Flame: Support for specifying username and password for message queue via 
+environment variables
 
 
 ## [0.12.0]

--- a/entropylab/flame/execute/_execute.py
+++ b/entropylab/flame/execute/_execute.py
@@ -42,6 +42,8 @@ class Execute:
         runtime_id = self.metadata.get("runtime_id", -1)
         self.routing_key = f"status_updates.{runtime_id}.{_Config.job_id}"
         self.runtime_state_info = RuntimeStateInfo()
+        # env variables FLAME_MESSAGING_USER_NAME and FLAME_MESSAGING_USER_PASS
+        # describes connection credentials for message queue
         self.message_queue_info = MessageQueueInfo()
 
     def __init_workflow(self):

--- a/entropylab/flame/execute/_message_queue_info.py
+++ b/entropylab/flame/execute/_message_queue_info.py
@@ -1,13 +1,19 @@
+import os
 import pika
 from pika.exchange_type import ExchangeType
 
 from entropylab.flame.execute._config import logger
 
 
+user = os.environ.get("FLAME_MESSAGING_USER_NAME", "flame_user")
+password = os.environ.get("FLAME_MESSAGING_USER_PASS", "flame_password")
+port = os.environ.get("FLAME_MESSAGING_PORT", "5672")
+
+
 def _setup_message_queue(host_url: str = "localhost"):
     logger.debug("MessageQueueInfo. Setup message queue")
     status_connection = pika.BlockingConnection(
-        pika.URLParameters(f"amqp://guest:guest@{host_url}:5672")
+        pika.URLParameters(f"amqp://{user}:{password}@{host_url}:{port}")
     )
     updates_channel = status_connection.channel()
     updates_channel.exchange_declare(


### PR DESCRIPTION
Added getting credentials for flame message queue user:
* `FLAME_MESSAGING_USER_NAME` - environment variable for username
* `FLAME_MESSAGING_USER_PASS` - environment variable for password