### PR TITLE
Params now have description & node_id attributes settable in set_param()

### DIFF
--- a/entropylab/pipeline/api/in_process_param_store.py
+++ b/entropylab/pipeline/api/in_process_param_store.py
@@ -224,18 +224,18 @@ class InProcessParamStore(ParamStore):
                 commit = self.__get_commit(commit_id)
                 return copy.deepcopy(commit["params"][key])
 
-    def set_param(self, key: str, value: object, expiration: Optional[timedelta]):
-
+    def set_param(self, key: str, value: object, **kwargs):
+        if "commit_id" in kwargs:
+            raise ValueError("Setting commit_id in set_param() is not allowed")
+        if "value" in kwargs:
+            raise ValueError("Value can only be set through positional argument")
         with self.__lock:
             if key in self.__params:
                 param = self.get_param(key)
             else:
                 param = Param(value)
             param.value = value
-            if expiration:
-                param.expiration = expiration
-            else:
-                param.expiration = None
+            param.__dict__.update(kwargs)
             self.__params.__setitem__(key, param)
             self.__is_dirty = True
             self.__dirty_keys.add(key)

--- a/entropylab/pipeline/api/param_store.py
+++ b/entropylab/pipeline/api/param_store.py
@@ -147,6 +147,8 @@ class Param(Dict):
         self.value: object = value
         self.commit_id: Optional[str] = None
         self.expiration: Optional[timedelta | int] = None
+        self.description: Optional[str] = None
+        self.node_id: Optional[str] = None
 
     def __repr__(self):
         return (


### PR DESCRIPTION
This PR, based on issue https://github.com/entropy-lab/entropy/issues/242,  adds two attributes to the `Param` objects stored in the `ParamStore`: `description` and `node_id`.

This is a small breaking changes to the signature of `ParamStore.set_param()` in that the attribute `expiration`, is no longer positional and instead is provided via `**kwargs`.