### PR TITLE
hotfix: flame > increase timeout limit for inital connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+### Fixed
+* Flame: hotfix, incread default timeout value for inital connection.
+
 ## [0.13.0] - 2022-06-19
 
 ### Added

--- a/entropylab/flame/execute/_utils.py
+++ b/entropylab/flame/execute/_utils.py
@@ -145,8 +145,8 @@ def parse_args():
         "-t",
         "--max-execution-time",
         type=int,
-        default=60,
-        help="Maximal execution time in s",
+        default=0,
+        help="Maximal execution time in s. Default 0 (no-limit).",
     )
     parser.add_argument(
         "-d",
@@ -174,8 +174,8 @@ def parse_args():
         "-c",
         "--connection-wait",
         type=int,
-        default=5,
+        default=60,
         help="How long in seconds to wait for succesful establishment of "
-        "communication between nodes before timeout.",
+        "communication between nodes before timeout. Default 60.",
     )
     return parser.parse_args()


### PR DESCRIPTION
Due to low initial connection timeout limit of 5s in Flame, when testing execution on slow virtual machines sometimes connection would timeout before programs are fully loaded. Now we wait for 60s by default which is more conservative.