### PR TITLE
New ParamStore method: diff()

### DIFF
--- a/entropylab/pipeline/api/in_process_param_store.py
+++ b/entropylab/pipeline/api/in_process_param_store.py
@@ -12,7 +12,7 @@ import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from random import SystemRandom
-from typing import Optional, Dict, Any, List, Callable, Set
+from typing import Optional, Dict, Any, List, Callable, Set, MutableMapping
 
 import jsonpickle as jsonpickle
 import pandas as pd
@@ -492,22 +492,41 @@ class InProcessParamStore(ParamStore):
 
     """ Diff """
 
-    def diff(self) -> Dict[str, Dict]:
+    def diff(
+        self, old_commit_id: Optional[str] = None, new_commit_id: Optional[str] = None
+    ) -> Dict[str, Dict]:
         with self.__lock:
-            diff = dict()
-            latest = self.__get_latest_commit()
-            old_params = latest["params"] if latest else {}
-            for key in self.__dirty_keys:
-                new_value = self.__safe_get_value_from_params(self.__params, key)
-                old_value = self.__safe_get_value_from_params(old_params, key)
-                if not old_value == new_value:
-                    if old_value and new_value:
-                        diff[key] = dict(old_value=old_value, new_value=new_value)
-                    elif old_value:
-                        diff[key] = dict(old_value=old_value)
-                    elif new_value:
-                        diff[key] = dict(new_value=new_value)
-            return diff
+
+            # get OLD params to diff:
+            if old_commit_id:
+                old_commit = self.__get_commit(old_commit_id)
+            else:  # default to latest commit
+                old_commit = self.__get_latest_commit()
+            old_params = old_commit["params"] if old_commit else {}
+
+            # get NEW params to diff:
+            if new_commit_id:
+                new_commit = self.__get_commit(new_commit_id)
+                new_params = new_commit["params"] if new_commit else {}
+            else:  # default to dirty params
+                new_params = self.__params
+
+            return self.__diff(old_params, new_params)
+
+    def __diff(self, old: MutableMapping, new: MutableMapping) -> Dict[str, Dict]:
+        diff = dict()
+        for key in new.keys():
+            if key in old.keys():
+                old_value = old[key].value
+                new_value = new[key].value
+                if old_value != new_value:  # different values
+                    diff[key] = dict(old_value=old_value, new_value=new_value)
+            else:
+                diff[key] = dict(new_value=new[key].value)  # added
+        for key in old.keys():
+            if key not in new.keys():
+                diff[key] = dict(old_value=old[key].value)  # deleted
+        return diff
 
     @staticmethod
     def __safe_get_value_from_params(params: Dict[str, Param], key: str) -> Optional:

--- a/entropylab/pipeline/api/param_store.py
+++ b/entropylab/pipeline/api/param_store.py
@@ -104,6 +104,18 @@ class ParamStore(ABC, MutableMapping):
     ) -> None:
         pass
 
+    @abstractmethod
+    def diff(self) -> Dict[str, Dict]:
+        """Shows the difference between the store's current state of params and the
+        latest committed params.
+
+        :returns: A dictionary where keys are the keys of params whose values have
+            changed. Dictionary values indicate the `old_value` of the param and the
+            `new_value` of the param. A new param will only show the `new_value`. A
+            deleted param will only show the `old_value`.
+            Example: {"foo": {"old_value": "bar", "new_value": "baz"}}"""
+        pass
+
     """ Tags """
 
     @abstractmethod

--- a/entropylab/pipeline/api/param_store.py
+++ b/entropylab/pipeline/api/param_store.py
@@ -105,15 +105,22 @@ class ParamStore(ABC, MutableMapping):
         pass
 
     @abstractmethod
-    def diff(self) -> Dict[str, Dict]:
-        """Shows the difference between the store's current state of params and the
-        latest committed params.
+    def diff(
+        self, old_commit_id: Optional[str] = None, new_commit_id: Optional[str] = None
+    ) -> Dict[str, Dict]:
+        """Shows the difference in Param values between two commits.
 
-        :returns: A dictionary where keys are the keys of params whose values have
+        :param old_commit_id: The id of the first ("older") commit to compare. If
+            None, or not specified, defaults to the latest commit id.
+        :param new_commit_id: The id of the second  ("newer") commit to compare. If
+            None, or not specified, defaults to the current state of the store (incl.
+             "dirty" values)
+        :return: A dictionary where keys are the keys of params whose values have
             changed. Dictionary values indicate the `old_value` of the param and the
             `new_value` of the param. A new param will only show the `new_value`. A
             deleted param will only show the `old_value`.
-            Example: {"foo": {"old_value": "bar", "new_value": "baz"}}"""
+            Example: {"foo": {"old_value": "bar", "new_value": "baz"}}
+        """
         pass
 
     """ Tags """

--- a/entropylab/pipeline/tests/test_param_store.py
+++ b/entropylab/pipeline/tests/test_param_store.py
@@ -347,8 +347,7 @@ def test_rename_key_when_key_has_a_tag_then_tag_remains():
     assert "tag" not in target.list_tags_for_key("foo")
 
 
-""" commit() """
-# edge cases: no commit yet, value does not exist int latest commit, value deleted
+""" diff() """
 
 
 def test_diff_existing_value_changed():
@@ -401,6 +400,31 @@ def test_diff__no_previous_commit_new_value_added_then_removed():
     del target["foo"]
     actual = target.diff()
     assert actual == {}
+
+
+def test_diff_when_commit_ids_are_given_then_they_are_used():
+    target = InProcessParamStore()
+    target.foo = "bar"
+    first = target.commit()
+    target.foo = "baz"
+    second = target.commit()
+    target.foo = "buzz"
+    actual = target.diff(first, second)
+    assert actual == {"foo": {"old_value": "bar", "new_value": "baz"}}
+
+
+def test_diff_when_commit_ids_are_used_in_reverse_then_result_is_reversed():
+    target = InProcessParamStore()
+    target.foo = "bar"
+    first = target.commit()
+    target.foo = "baz"
+    second = target.commit()
+    target.foo = "buzz"
+    actual = target.diff(second, first)
+    assert actual == {"foo": {"old_value": "baz", "new_value": "bar"}}
+
+
+""" commit() """
 
 
 def test_commit_in_memory_when_param_changes_commit_doesnt_change():

--- a/entropylab/pipeline/tests/test_param_store.py
+++ b/entropylab/pipeline/tests/test_param_store.py
@@ -348,6 +348,59 @@ def test_rename_key_when_key_has_a_tag_then_tag_remains():
 
 
 """ commit() """
+# edge cases: no commit yet, value does not exist int latest commit, value deleted
+
+
+def test_diff_existing_value_changed():
+    target = InProcessParamStore()
+    target.foo = "bar"
+    target.commit()
+    target.foo = "baz"
+    actual = target.diff()
+    assert actual == {"foo": {"old_value": "bar", "new_value": "baz"}}
+
+
+def test_diff_existing_value_changed_and_changed_back():
+    target = InProcessParamStore()
+    target.foo = "bar"
+    target.commit()
+    target.foo = "baz"
+    target.foo = "bar"
+    actual = target.diff()
+    assert actual == {}
+
+
+def test_diff_existing_value_deleted():
+    target = InProcessParamStore()
+    target.foo = "bar"
+    target.commit()
+    del target["foo"]
+    actual = target.diff()
+    assert actual == {"foo": {"old_value": "bar"}}
+
+
+def test_diff_new_value_added():
+    target = InProcessParamStore()
+    target.foo = "bar"
+    target.commit()
+    target.boo = "baz"
+    actual = target.diff()
+    assert actual == {"boo": {"new_value": "baz"}}
+
+
+def test_diff__no_previous_commit_new_value_added():
+    target = InProcessParamStore()
+    target.foo = "bar"
+    actual = target.diff()
+    assert actual == {"foo": {"new_value": "bar"}}
+
+
+def test_diff__no_previous_commit_new_value_added_then_removed():
+    target = InProcessParamStore()
+    target.foo = "bar"
+    del target["foo"]
+    actual = target.diff()
+    assert actual == {}
 
 
 def test_commit_in_memory_when_param_changes_commit_doesnt_change():
@@ -1158,17 +1211,3 @@ def test_multi_processes_do_not_conflict(tinydb_file_path):
     ps = InProcessParamStore(tinydb_file_path)
     names = ps.list_values("name")["value"]
     assert all(names.value_counts() == num_of_commits)
-
-
-# def test():
-#     target = InProcessParamStore("C:\\Users\\uri_g\\Desktop\\bug\\.entropy\\params.db")
-#     actual = target["q0_f_if_01"]
-#
-#
-# def test2():
-#     target = InProcessParamStore(
-#         "C:\\Users\\uri_g\\Desktop\\bug\\.entropy\\params_new.db"
-#     )
-#     target["q0_f_if_01"] = 42.0
-#     target.commit()
-#     actual = target["q0_f_if_01"]


### PR DESCRIPTION
This PR addresses issue https://github.com/entropy-lab/entropy/issues/243. It introduces a new method called `diff()` to the ParamStore ABC and implementation. 

The new method shows the difference between the store's current state of params and the latest committed params. It returns a dictionary where keys are the keys of params whose values have changed. 

Dictionary values indicate the `old_value` of the param and the `new_value` of the param. A new param will only show the `new_value`. A deleted param will only show the `old_value`. 

For example: `{"foo": {"old_value": 42, "new_value": 1337}}"""`
