### PR TITLE
ParamStore commit and expiration times are now displayed in local tim…

### DIFF
--- a/entropylab/pipeline/api/in_process_param_store.py
+++ b/entropylab/pipeline/api/in_process_param_store.py
@@ -24,7 +24,13 @@ from tinydb.table import Table
 
 from entropylab.logger import logger
 from entropylab.pipeline.api.errors import EntropyError
-from entropylab.pipeline.api.param_store import ParamStore, MergeStrategy, Param
+from entropylab.pipeline.api.param_store import (
+    ParamStore,
+    MergeStrategy,
+    Param,
+    LOCAL_TZ,
+    _ns_to_datetime,
+)
 
 CURRENT_VERSION = 0.2
 
@@ -644,11 +650,6 @@ def _json_dumps_default(value):
         return str(value)
     else:
         return value.__dict__
-
-
-def _ns_to_datetime(ns: int) -> pd.datetime:
-    """Convert a UNIX epoch timestamp in nano-seconds to a human readable string"""
-    return pd.to_datetime(ns)
 
 
 def _map_dict(f, d: Dict) -> Dict:

--- a/entropylab/pipeline/api/in_process_param_store.py
+++ b/entropylab/pipeline/api/in_process_param_store.py
@@ -28,7 +28,6 @@ from entropylab.pipeline.api.param_store import (
     ParamStore,
     MergeStrategy,
     Param,
-    LOCAL_TZ,
     _ns_to_datetime,
 )
 

--- a/entropylab/pipeline/api/param_store.py
+++ b/entropylab/pipeline/api/param_store.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import time
 from abc import ABC, abstractmethod
-from datetime import timedelta
+from datetime import datetime, timedelta
 from enum import Enum, unique
 from typing import Dict, List, Optional, MutableMapping
 
 import pandas as pd
+
+LOCAL_TZ = datetime.now().astimezone().tzinfo
 
 
 @unique
@@ -196,6 +198,5 @@ class Param(Dict):
 
 
 def _ns_to_datetime(ns: int) -> pd.datetime:
-    """
-    Converts a UNIX epoch timestamp in nano-seconds to a human readable string"""
-    return pd.to_datetime(ns)
+    """Convert a UNIX epoch timestamp in nano-seconds to pandas Timestamp in local TZ"""
+    return pd.to_datetime(ns, utc=True).tz_convert(LOCAL_TZ)

--- a/entropylab/pipeline/tests/test_param_store.py
+++ b/entropylab/pipeline/tests/test_param_store.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from pprint import pprint
 from time import sleep
 
+import pandas as pd
 import pytest
 from tinydb import Query, TinyDB
 
@@ -17,7 +18,7 @@ from entropylab.pipeline.api.in_process_param_store import (
     JSONPickleStorage,
     fix_param_qualified_name,
 )
-from entropylab.pipeline.api.param_store import Param
+from entropylab.pipeline.api.param_store import Param, LOCAL_TZ, _ns_to_datetime
 
 """ ctor """
 
@@ -1235,3 +1236,9 @@ def test_multi_processes_do_not_conflict(tinydb_file_path):
     ps = InProcessParamStore(tinydb_file_path)
     names = ps.list_values("name")["value"]
     assert all(names.value_counts() == num_of_commits)
+
+
+def test__ns_to_datetime():
+    expected = pd.Timestamp("2022-07-10 11:40:37.233137200+0300", tz=LOCAL_TZ)
+    actual = _ns_to_datetime(1657442437233137200)
+    assert actual == expected


### PR DESCRIPTION
This PR resolves https://github.com/entropy-lab/entropy/issues/221. 

`ParamStore` commit and expiration times are stored as UNIX epoch timestamps (in nano-seconds) in the `ParamStore` DB. This PR converts these times to the local timezone when they are displayed to users. Ex: `list_values()`, `__repr__()` for `Metadata` and `Param` instances.