### PR TITLE
ParamStore `commit()` now commits regardless of the state of `is_dirty`

### DIFF
--- a/entropylab/pipeline/api/in_process_param_store.py
+++ b/entropylab/pipeline/api/in_process_param_store.py
@@ -31,7 +31,7 @@ from entropylab.pipeline.api.param_store import (
     _ns_to_datetime,
 )
 
-CURRENT_VERSION = 0.2
+CURRENT_VERSION = "0.2"
 
 INFO_DOC_ID = 1
 INFO_TABLE = "info"
@@ -291,8 +291,6 @@ class InProcessParamStore(ParamStore):
 
     def commit(self, label: Optional[str] = None) -> str:
         with self.__lock:
-            if not self.__is_dirty:
-                return self.__base_commit_id
             commit_id = self.__generate_commit_id()
             commit_timestamp = time.time_ns()  # nanoseconds since epoch
             self.__stamp_dirty_params_with_commit(commit_id, commit_timestamp)
@@ -518,7 +516,8 @@ class InProcessParamStore(ParamStore):
 
             return self.__diff(old_params, new_params)
 
-    def __diff(self, old: MutableMapping, new: MutableMapping) -> Dict[str, Dict]:
+    @staticmethod
+    def __diff(old: MutableMapping, new: MutableMapping) -> Dict[str, Dict]:
         diff = dict()
         for key in new.keys():
             if key in old.keys():

--- a/entropylab/pipeline/tests/test_param_store.py
+++ b/entropylab/pipeline/tests/test_param_store.py
@@ -445,11 +445,11 @@ def test_commit_when_body_is_empty_does_not_throw(tinydb_file_path):
     assert len(target.commit()) == 40
 
 
-def test_commit_when_committing_non_dirty_does_nothing(tinydb_file_path):
+def test_commit_when_committing_non_dirty_commits(tinydb_file_path):
     target = InProcessParamStore(tinydb_file_path)
     first = target.commit()
     second = target.commit()
-    assert first == second
+    assert first != second
 
 
 def test_commit_when_committing_same_state_twice_a_different_id_is_returned(


### PR DESCRIPTION
This PR enables `InProcessParamStore`'s uses to commit the contents of the param store to disk even when the `is_dirty` property's value is `False`. This is useful in case where changes to values nested inside param store values are changed but the param store has not detected the change.