### PR TITLE
_dir__() method for InProcessParamStore adds param keys to auto-complete

### DIFF
--- a/entropylab/pipeline/api/in_process_param_store.py
+++ b/entropylab/pipeline/api/in_process_param_store.py
@@ -219,6 +219,10 @@ class InProcessParamStore(ParamStore):
         with self.__lock:
             return self.__params.__contains__(key)
 
+    def __dir__(self):
+        with self.__lock:
+            return super().__dir__() + list(self.__params.keys())
+
     def __repr__(self):
         with self.__lock:
             return f"<InProcessParamStore({self.to_dict().__repr__()})>"

--- a/entropylab/pipeline/tests/test_param_store.py
+++ b/entropylab/pipeline/tests/test_param_store.py
@@ -150,6 +150,24 @@ def test___delitem___when_key_is_deleted_then_it_is_removed_from_tags_too():
     assert target.list_keys_for_tag("tag") == ["goo"]
 
 
+def test_dir_when_key_is_in_param_store_then_it_is_in_result():
+    target = InProcessParamStore()
+    target.foo = "bar"
+    target["baz"] = "42"
+    actual = dir(target)
+    assert "foo" in actual
+    assert "baz" in actual
+    assert "commit" in actual
+
+
+def test_dir_when_key_is_removed_then_its_not_in_result():
+    target = InProcessParamStore()
+    target["foo"] = "bar"
+    assert "foo" in dir(target)
+    del target["foo"]
+    assert "foo" not in dir(target)
+
+
 def test___repr__():
     target = InProcessParamStore()
     target["foo"] = "bar"


### PR DESCRIPTION
This PR resolves https://github.com/entropy-lab/entropy/issues/244. Customers have requested that param keys entered into a `ParamStore` instance will be available for attribute auto-completion in common IDEs (specifically PyCharm). This PR adds an overriding implementation to `InProcessParamStore`'s `__dir__()` method that returns both the keys in the store and the store's attribute, methods and properties.