### PR TITLE
Fix: ParamStore.save_temp() can be called more than once (using SqlAlchemyPersistence)

### DIFF
--- a/entropylab/pipeline/params/param_store.py
+++ b/entropylab/pipeline/params/param_store.py
@@ -38,6 +38,12 @@ class Param(Dict):
         self.description: Optional[str] = None
         self.node_id: Optional[str] = None
 
+    def __eq__(self, other):
+        return self.value == other.value
+
+    def __hash__(self):
+        return hash(self.value)
+
     def __repr__(self):
         return (
             f"<Param(value={self.value}, "


### PR DESCRIPTION
This PR fixes an issue where when using `ParamStore` with a relational DB persistence backend, calling `save_temp()` would raise an exception.

The root cause was that the implementation of `save_temp_commit()` in `SqlAlchemyPersistence` would always try to insert the temp commit record into the relevant table. The fix is a proper implementation of "upsert" in that method.

Additionally, the PR also adds implementation for `__eq()__` and `__hash()__` in the `Param` class. These are required for SqlAlchemy to correctly identify when a temp commit record (type: `TempTable`) has changed and save the change to the DB.