### PR TITLE
Fix: ParamStore save_temp() would throw when called twice (with numpy ndarray values)

### DIFF
--- a/entropylab/pipeline/params/param_store.py
+++ b/entropylab/pipeline/params/param_store.py
@@ -8,6 +8,7 @@ from enum import unique, Enum
 from pathlib import Path
 from typing import Optional, Dict, Any, List, Set, MutableMapping
 
+import numpy as np
 import pandas as pd
 
 from entropylab.config import settings
@@ -39,7 +40,13 @@ class Param(Dict):
         self.node_id: Optional[str] = None
 
     def __eq__(self, other):
-        return self.value == other.value
+        if isinstance(self.value, np.ndarray):  # numpy arrays
+            if np.issubdtype(self.value.dtype, np.float):  # dtype float
+                return np.allclose(self.value, other.value, atol=1e-09, rtol=0.0)
+            else:  # non-float dtype
+                return (self.value == other.value).all()
+        else:  # everything else
+            return self.value == other.value
 
     def __hash__(self):
         return hash(self.value)

--- a/entropylab/pipeline/params/tests/test_param_store.py
+++ b/entropylab/pipeline/params/tests/test_param_store.py
@@ -5,6 +5,7 @@ from pprint import pprint
 from time import sleep
 from typing import Callable
 
+import numpy as np
 import pandas as pd
 import pytest
 from tinydb import TinyDB
@@ -1066,6 +1067,13 @@ def test_save_temp_can_be_called_more_than_once(target):
     assert target.foo == "baz"
 
 
+def test_save_temp_when_ndarray_is_saved_twice_then_no_error_occurs(target):
+    target.foo = np.random.randn(2)
+    target.save_temp()
+    target.foo = np.random.randn(2)
+    target.save_temp()
+
+
 def test_load_temp_when_save_temp_not_called_before_then_error_is_raised(target):
     with pytest.raises(EntropyError):
         target.load_temp()
@@ -1192,6 +1200,35 @@ def test_fix_param_qualified_name(tinydb_file_path, request):
 
 
 """ class Param """
+
+
+@pytest.mark.parametrize(
+    "value,other",
+    [
+        (42, 42),
+        ("foo", "foo"),
+        (1.9999999999, 1.9999999999),
+        (np.array([1]), np.array([1])),
+        (np.array([1, 1.999999999]), np.array([1, 1.999999999])),
+        (np.array([1, 1.9999999999]), np.array([1, 1.9999999998])),
+    ],
+)
+def test___eq___expecting_true(value, other):
+    assert Param(value) == Param(other)
+
+
+@pytest.mark.parametrize(
+    "value,other",
+    [
+        (42, 41),
+        ("foo", "bar"),
+        (1.9999999999, 1.9999999998),
+        (np.array([1, 1]), np.array([1, 2])),
+        (np.array([1, 1.99999999]), np.array([1, 1.99999998])),
+    ],
+)
+def test___eq___expecting_false(value, other):
+    assert not (Param(value) == Param(other))
 
 
 def test_has_expired_when_expiration_is_int_and_has_expired_then_true():


### PR DESCRIPTION
This PR fixes a bug where if you tried to `save_temp()` when the `ParamStore` contained a numpy `ndarray` with 2 or more values an exception would be raised (`ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`)

The cause of the exception was that on the second call to `save_temp()`, when updating the DB "temp" record, SqlAlchemy compared the `Param` from the DB with the new `Param` value using the `Param` class' `__eq__()`. This involved a simple `==` comparison which triggered the exception.

The fix provides a more elaborate implementation of `__eq__()` that handles `ndarray`s as special cases and compares them using recommended numpy comparison methods.