### PR TITLE
_dir__() method for ParamStore adds Param keys to auto-complete

### DIFF
--- a/entropylab/pipeline/params/param_store.py
+++ b/entropylab/pipeline/params/param_store.py
@@ -182,6 +182,10 @@ class ParamStore(MutableMapping):
         with self.__lock:
             return self.__params.__contains__(key)
 
+    def __dir__(self):
+        with self.__lock:
+            return super().__dir__() + list(self.__params.keys())
+
     def __repr__(self):
         with self.__lock:
             return f"<ParamStore({self.to_dict().__repr__()})>"

--- a/entropylab/pipeline/params/tests/test_param_store.py
+++ b/entropylab/pipeline/params/tests/test_param_store.py
@@ -174,6 +174,22 @@ def test___delitem___when_key_is_deleted_then_it_is_removed_from_tags_too(target
     assert target.list_keys_for_tag("tag") == ["goo"]
 
 
+def test___dir___when_key_is_in_param_store_then_it_is_in_result(target):
+    target.foo = "bar"
+    target["baz"] = "42"
+    actual = dir(target)
+    assert "foo" in actual
+    assert "baz" in actual
+    assert "commit" in actual
+
+
+def test___dir___when_key_is_removed_then_its_not_in_result(target):
+    target["foo"] = "bar"
+    assert "foo" in dir(target)
+    del target["foo"]
+    assert "foo" not in dir(target)
+
+
 def test___repr__(target):
     target["foo"] = "bar"
     actual = target.__repr__()


### PR DESCRIPTION
This PR resolves https://github.com/entropy-lab/entropy/issues/244. Customers have requested that param keys entered into a `ParamStore` instance will be available for attribute auto-completion in common IDEs (specifically PyCharm). This PR adds an overriding implementation to `InProcessParamStore`'s `__dir__()` method that returns both the keys in the store and the store's attribute, methods and properties.